### PR TITLE
Rename _build to _jbuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-_build
+_jbuild
 *.install
 boot.exe
 .merlin

--- a/CHANGES.org
+++ b/CHANGES.org
@@ -1,6 +1,6 @@
 * 1.0
 
-- Generate a log in =_build/log=
+- Generate a log in =_jbuild/log=
 
 - Improve the output of jbuilder, in particular don't mangle the
   output of commands when using =-j N= with =N > 1=

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 INSTALL_ARGS := $(if $(PREFIX),--prefix $(PREFIX),)
-BIN := ./_build/default/bin/main.exe
+BIN := ./_jbuild/default/bin/main.exe
 
 default: boot.exe
 	./boot.exe -j 4 --dev
@@ -19,6 +19,6 @@ all-supported-ocaml-versions:
 	$(BIN) build @install --workspace jbuild-workspace.dev --root .
 
 clean:
-	rm -rf _build
+	rm -rf _jbuild
 
 .PHONY: default install uninstall reinstall clean

--- a/doc/manual.org
+++ b/doc/manual.org
@@ -72,7 +72,7 @@ format and the third one describes how to use the =jbuilder= command.
   takes for granted and doesn't know how to build
 
 - *build context*: a build context is a subdirectory of the
-  =<root>/_build= directory. It contains all the build artifacts of
+  =<root>/_jbuild= directory. It contains all the build artifacts of
   the workspace built against a specific configuration. Without
   specific configuration from the user, there is always a =default=
   build context, which correspond to the environment in which Jbuilder
@@ -80,7 +80,7 @@ format and the third one describes how to use the =jbuilder= command.
   [[jbuild-workspace]] file
 
 - *build context root*: the root of a build context named =foo= is
-  =<root>/_build/<foo>=
+  =<root>/_jbuild/<foo>=
 
 - *alias*: an alias is a build target that doesn't produce any file
   and has configurable dependencies. Alias are per-directory and some

--- a/doc/quick-start.org
+++ b/doc/quick-start.org
@@ -21,7 +21,7 @@ And build it with:
 jbuilder hello_world.exe
 #+end_src
 
-The executable will be built as =_build/default/hello_world.exe=
+The executable will be built as =_jbuild/default/hello_world.exe=
 
 * Building a hello world program using Lwt
 
@@ -45,7 +45,7 @@ And build it with:
 jbuilder hello_world.exe
 #+end_src
 
-The executable will be built as =_build/default/hello_world.exe=
+The executable will be built as =_jbuild/default/hello_world.exe=
 
 * Defining a library using Lwt and ocaml-re
 

--- a/src/alias.ml
+++ b/src/alias.ml
@@ -15,7 +15,7 @@ type t =
   ; file : Path.t
   }
 
-let aliases_path = Path.(relative root) "_build/.aliases"
+let aliases_path = Path.(relative root) "_jbuild/.aliases"
 
 let of_path path =
   if not (Path.is_local path) then
@@ -78,7 +78,7 @@ let rules store ~prefixes ~tree =
   List.iter prefixes ~f:(fun prefix ->
     setup_rec_aliases store ~prefix ~tree);
 
-  (* For each alias @_build/blah/../x, add a dependency: @../x --> @_build/blah/../x *)
+  (* For each alias @_jbuild/blah/../x, add a dependency: @../x --> @_jbuild/blah/../x *)
   Hashtbl.fold store ~init:[] ~f:(fun ~key:_ ~data:{ Store. alias; _ } acc ->
     match Path.extract_build_context (Name.path alias.name) with
     | None -> acc

--- a/src/config.ml
+++ b/src/config.ml
@@ -1,7 +1,7 @@
 open! Import
 
 let local_install_dir =
-  let dir = Path.(relative root) "_build/install" in
+  let dir = Path.(relative root) "_jbuild/install" in
   fun ~context -> Path.relative dir context
 
 let local_install_bin_dir ~context =

--- a/src/context.ml
+++ b/src/context.ml
@@ -134,7 +134,7 @@ let create ~(kind : Kind.t) ~path ~env ~name ~merlin =
     | Some fn -> fn
   in
   let build_dir =
-    Path.of_string (sprintf "_build/%s" name)
+    Path.of_string (sprintf "_jbuild/%s" name)
   in
   let ocamlc_config_cmd = sprintf "%s -config" (Path.to_string ocamlc) in
   both

--- a/src/context.mli
+++ b/src/context.mli
@@ -8,10 +8,10 @@
 
     - opam switch contexts, where one opam switch correspond to one context
 
-    each context is built into a sub-directory of "_build":
+    each context is built into a sub-directory of "_jbuild":
 
-    - _build/default for the default context
-    - _build/<switch> for other contexts
+    - _jbuild/default for the default context
+    - _jbuild/<switch> for other contexts
 
     jbuild is able to build simultaneously against several contexts. In particular this
     allow for simple cross-compilation: when an executable running on the host is needed,
@@ -41,7 +41,7 @@ type t =
         building tools used for the compilation that run on the host. *)
     for_host : t option
 
-  ; (** Directory where artifact are stored, for instance "_build/default" *)
+  ; (** Directory where artifact are stored, for instance "_jbuild/default" *)
     build_dir : Path.t
 
   ; (** [PATH] *)

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -27,6 +27,7 @@ let root t = t.root
 let ignore_file = function
   | ""
   | "_build"
+  | "_jbuild"
   | ".git"
   | ".hg"
   | "_darcs"

--- a/src/jbuild_load.ml
+++ b/src/jbuild_load.ml
@@ -14,7 +14,7 @@ module Jbuilds = struct
 
   type t = one list
 
-  let generated_jbuilds_dir = Path.(relative root) "_build/.jbuilds"
+  let generated_jbuilds_dir = Path.(relative root) "_jbuild/.jbuilds"
 
   let ensure_parent_dir_exists path =
     match Path.kind path with

--- a/src/main.ml
+++ b/src/main.ml
@@ -110,9 +110,9 @@ let report_error ?map_fname ppf exn =
     report_error ?map_fname ppf exn ~backtrace
 
 let create_log () =
-  if not (Sys.file_exists "_build") then
-    Unix.mkdir "_build" 0o777;
-  let oc = open_out_bin "_build/log" in
+  if not (Sys.file_exists "_jbuild") then
+    Unix.mkdir "_jbuild" 0o777;
+  let oc = open_out_bin "_jbuild/log" in
   Printf.fprintf oc "# %s\n%!"
     (String.concat (List.map (Array.to_list Sys.argv) ~f:quote_for_shell) ~sep:" ");
   oc

--- a/src/path.ml
+++ b/src/path.ml
@@ -234,7 +234,7 @@ let parent t =
   else
     Filename.dirname t
 
-let build_prefix = "_build/"
+let build_prefix = "_jbuild/"
 
 let is_in_build_dir t =
   String.is_prefix t ~prefix:build_prefix


### PR DESCRIPTION
_build is already quite overloaded.

This was a search and replace job. Would probably be better if this was just a
constant somewhere