### PR TITLE
add workspace file, so it  jbuilder do not crash

### DIFF
--- a/doc/quick-start.org
+++ b/doc/quick-start.org
@@ -9,6 +9,12 @@ In a directory of your choice, write this =jbuild= file:
  ((names (hello_world))))
 #+end_src
 
+add a workspace file 
+
+#+begin_src scheme
+echo '(context ((switch 4.03.0)))' > jbuild-workspace
+#+end_src
+
 This =hello_world.ml= file:
 
 #+begin_src ocaml


### PR DESCRIPTION
in my machine, without it. 
```
Workspace root: /home/hwu
Running[0]: /home/hwu/.opam/4.03.0/bin/ocamlc.opt -config > /tmp/jbuildc54061.output
Running[1]: /home/hwu/.opam/4.03.0/bin/ocamlfind printconf path > /tmp/jbuild6a3783.output
Running[2]: /usr/bin/opam config var lib > /tmp/jbuild60609c.output
Error: exception Stack overflow
Backtrace:
```

workspace searching cost too much time and mem?