### PR TITLE
Fix the runtest alias example.

### DIFF
--- a/doc/quick-start.org
+++ b/doc/quick-start.org
@@ -180,7 +180,7 @@ Write this in your =jbuild= file:
 
 #+begin_src scheme
 (alias
- ((name    (runtest))
+ ((name    runtest)
   (deps    (my-test-program.exe))
   (action  (run ${<}))))
 #+end_src


### PR DESCRIPTION
When running "jbuilder runtest" with "(name (runtest)))" in my jbuild, I got "Error: Atom expected". It seems that removing the extra parenthesis fixes this and is in line with the manual.