### PR TITLE
Menhir support - first pass

### DIFF
--- a/doc/manual.org
+++ b/doc/manual.org
@@ -521,7 +521,8 @@ The basic form for defining menhir parsers (analogous to ocamlyacc):
  ((modules (<parser1> <parser2> ...))))
 #+end_src
 
-Modular parsers (--base flag) can be defined by adding the `merge_into` option:
+Modular parsers (--base flag) can be defined by adding the =merge_into= option.
+With this option, a single parser named =base_name= is generated.
 
 #+begin_src scheme
 (menhir
@@ -529,7 +530,7 @@ Modular parsers (--base flag) can be defined by adding the `merge_into` option:
   (modules (<parser1> <parser2> ...))))
 #+end_src
 
-Extra parsers can be passed to menhir using the `flags` option:
+Extra flags can be passed to menhir using the =flags= option:
 
 #+begin_src scheme
 (menhir

--- a/doc/manual.org
+++ b/doc/manual.org
@@ -501,7 +501,6 @@ dependencies. See the [[User actions][actions section]] for more details.
    (deps    (<name>.mll))
    (action  (chdir ${ROOT} (run ${bin:ocamllex} -q -o ${<})))))
 #+end_src
-
 **** ocamlyacc
 
 =(ocamlyacc (<names>))= is essentially a shorthand for:
@@ -511,6 +510,31 @@ dependencies. See the [[User actions][actions section]] for more details.
   ((targets (<name>.ml <name>.mli))
    (deps    (<name>.mly))
    (action  (chdir ${ROOT} (run ${bin:ocamlyacc} ${<})))))
+#+end_src
+
+**** menhir
+
+The basic form for defining menhir parsers (analogous to ocamlyacc):
+
+#+begin_src scheme
+(menhir
+ ((modules (<parser1> <parser2> ...))))
+#+end_src
+
+Modular parsers (--base flag) can be defined by adding the `merge_into` option:
+
+#+begin_src scheme
+(menhir
+ ((merge_into <base_name>)
+  (modules (<parser1> <parser2> ...))))
+#+end_src
+
+Extra parsers can be passed to menhir using the `flags` option:
+
+#+begin_src scheme
+(menhir
+ ((flags (<option1> <option2> ...))
+  (modules (<parser1> <parser2> ...))))
 #+end_src
 
 **** alias

--- a/src/jbuild_types.ml
+++ b/src/jbuild_types.ml
@@ -687,7 +687,7 @@ module Menhir = struct
 
   let v1 =
     record
-      (field_o "base" string >>= fun base ->
+      (field_o "merge_into" string >>= fun base ->
        field "flags" (list String_with_vars.t) ~default:[] >>= fun flags ->
        field "modules" (list string) >>= fun modules ->
        return

--- a/test/jbuild
+++ b/test/jbuild
@@ -26,6 +26,14 @@
     (run ${exe:run.exe} --
      ${bin:jbuilder} build -j1 @install --root . --debug-dependency-path)))))
 
+(alias
+ ((name runtest)
+  (deps ((files_recursively_in workspaces/menhir)))
+  (action
+   (chdir workspaces/menhir
+    (run ${exe:run.exe} --
+     ${bin:jbuilder} build -j1 test.exe --root . --debug-dependency-path)))))
+
 ;; This test define an installed "plop" with a "plop.ca-marche-pas"
 ;; sub-package which depend on a library that doesn't exist.
 ;;

--- a/test/workspaces/menhir/jbuild
+++ b/test/workspaces/menhir/jbuild
@@ -1,0 +1,14 @@
+(jbuild_version 1)
+
+(ocamllex (lexer1 lexer2))
+
+(menhir
+ ((modules (test_menhir1))))
+
+(menhir
+ ((base test_base)
+  (flags (--explain))
+  (modules (tokens parser))))
+
+(executables
+ ((names (test))))

--- a/test/workspaces/menhir/jbuild
+++ b/test/workspaces/menhir/jbuild
@@ -6,7 +6,7 @@
  ((modules (test_menhir1))))
 
 (menhir
- ((base test_base)
+ ((merge_into test_base)
   (flags (--explain))
   (modules (tokens parser))))
 

--- a/test/workspaces/menhir/lexer1.mll
+++ b/test/workspaces/menhir/lexer1.mll
@@ -1,0 +1,7 @@
+{
+open Test_menhir1
+}
+
+rule lex = parse
+  | 'c' { TOKEN 'c' }
+  | eof { EOF }

--- a/test/workspaces/menhir/lexer2.mll
+++ b/test/workspaces/menhir/lexer2.mll
@@ -1,0 +1,7 @@
+{
+open Test_base
+}
+
+rule lex = parse
+  | 'c' { TOKEN 'c' }
+  | eof { EOF }

--- a/test/workspaces/menhir/parser.mly
+++ b/test/workspaces/menhir/parser.mly
@@ -1,0 +1,7 @@
+%start <char list> main
+
+%%
+
+main:
+| c = TOKEN EOF { [c] }
+| c = TOKEN xs = main  { c :: xs }

--- a/test/workspaces/menhir/test.ml
+++ b/test/workspaces/menhir/test.ml
@@ -1,0 +1,8 @@
+
+let s = "foo bar baz"
+
+let () =
+  let lex1 = Lexing.from_string s in
+  let lex2 = Lexing.from_string s in
+  ignore (Test_menhir1.main Lexer1.lex lex1);
+  ignore (Test_base.main Lexer2.lex lex2)

--- a/test/workspaces/menhir/test_menhir1.mly
+++ b/test/workspaces/menhir/test_menhir1.mly
@@ -1,0 +1,10 @@
+%token <char> TOKEN
+%token EOF
+
+%start <char list> main
+
+%%
+
+main:
+| c = TOKEN EOF { [c] }
+| c = TOKEN xs = main  { c :: xs }

--- a/test/workspaces/menhir/tokens.mly
+++ b/test/workspaces/menhir/tokens.mly
@@ -1,0 +1,5 @@
+%token <char> TOKEN
+%token EOF
+
+%%
+


### PR DESCRIPTION
Here's something basic that seems to work in most of the simple menhir
projects I've encountered.

Some things to note:
* I'm not sure if it's a good idea to support simple menhir and `--base` in the
  same stanza. For example omake supports a separate `MenhirMulti` function
  and ocamlbuild has mlypack just for modular menhir

* I'm pretty sure my flags handling is wrong. But there has to be something
  in place to pass extra flags to menhir

* All the ocamlc/ocamldep stuff is avoided for now. This PR seems to be
  sufficient for most (simple) uses of menhir out there. So perhaps this can
  be marked as experimental an improved eventually.

* I don't whether I should add stuff to vjs, as I'm guessing you want to have
  tight control over that at JST.