### PR TITLE
[RFC] simplify the jbuilder invocation in opam files

### DIFF
--- a/doc/manual.org
+++ b/doc/manual.org
@@ -1178,8 +1178,11 @@ You should set the =build:= field of your =<package>.opam= file as
 follows:
 
 #+begin_src
-build: [["jbuilder" "build" "--only-packages" "<package>" "--root" "." "-j" jobs "@install"]]
+build: [["jbuilder" "build" "-p" "<package>" "-j" jobs]]
 #+end_src
+
+=-p pkg= is a shorthand for =--root . --only-packages pkg=. =-p= is
+the short version of =--for-release-of-packages=.
 
 This has the following effects:
 - it tells jbuilder to build everything that is installable and to

--- a/src/main.ml
+++ b/src/main.ml
@@ -24,7 +24,7 @@ let setup ?(log=Log.no_log) ?filter_out_optional_stanzas_with_missing_deps
     String_set.iter set ~f:(fun pkg ->
       if not (String_map.mem pkg conf.packages) then
         die "@{<error>Error@}: I don't know about package %s \
-             (passed through --only-packages)%s"
+             (passed through --only-packages/--release)%s"
           pkg (hint pkg (String_map.keys conf.packages))));
   let workspace =
     match workspace with

--- a/src/ml_kind.ml
+++ b/src/ml_kind.ml
@@ -14,8 +14,6 @@ let flag t = choose (Arg_spec.A "-impl") (A "-intf") t
 
 let ppx_driver_flag t = choose (Arg_spec.A "--impl") (A "--intf") t
 
-let ext = choose ".ml" ".mli"
-
 module Dict = struct
   type 'a t =
     { impl : 'a

--- a/src/ml_kind.mli
+++ b/src/ml_kind.mli
@@ -7,8 +7,6 @@ val suffix : t -> string
 
 val to_string : t -> string
 
-val ext : t -> string
-
 val flag : t -> _ Arg_spec.t
 val ppx_driver_flag : t -> _ Arg_spec.t
 


### PR DESCRIPTION
The jbuilder command line in opam files is too long:

```
build: [
  ["jbuilder" "build" "@install" "--root" "." "--only" "utop" "-j" jobs]
]
```

And it might get longer if we add support for configuration files in the future:

```
build: [
  ["jbuilder" "build" "@install" "--root" "." "--only" "utop" "--no-config" "-j" jobs]
]
```

This PR adds a `--release pkg` option which is a shorthand for `--root . --only-package pkg`, and later might also include `--no-config`. With this and #47, we can simplify the invocation to:

```
build: [
  ["jbuilder" "build" "--release" "utop" "-j" jobs]
]
```
I'm not sure about the name of the option though. Suggestions welcome. Another possibility is to add a separate command, however we need the same thing for tests, so an option seems better.

