### PR TITLE
Allow to disable support for dynlink

### DIFF
--- a/CHANGES.org
+++ b/CHANGES.org
@@ -15,6 +15,9 @@
   the alias module with 4.02 to workaround the compiler trying to read
   the cmi of the aliased modules
 
+- Allow to disable dynlink support for libraries via =(no_dynlink)=
+  (#55)
+
 * 1.0+beta6 (29/03/2017)
 
 - Add an =(executable ...)= stanza for single executables (#33)

--- a/doc/manual.org
+++ b/doc/manual.org
@@ -337,6 +337,9 @@ the library and you are free to expose only the modules you want.
   built by default. This is only useful when writing libraries for the
   OCaml toplevel
 
+- =(no_dynlink)= is to disable dynamic linking of the library. This is
+  for advanced use only, by default you shouldn't set this option
+
 - =(kind <kind>)= is the kind of the library. The default is =normal=,
   other available choices are =ppx_rewriter= and =ppx_deriver= and
   must be set when the library is intended to be used as a ppx

--- a/src/gen_meta.ml
+++ b/src/gen_meta.ml
@@ -54,7 +54,6 @@ let archives ?(preds=[]) name =
   ; plugin  (preds @ [Pos "byte"  ]) (name ^ ".cma" )
   ; plugin  (preds @ [Pos "native"]) (name ^ ".cmxs")
   ]
-let exists_if fn = rule "exists_if" [] Set fn
 
 let gen_lib pub_name (lib : Library.t) ~lib_deps ~ppx_runtime_deps:ppx_rt_deps ~version =
   let desc =
@@ -77,7 +76,6 @@ let gen_lib pub_name (lib : Library.t) ~lib_deps ~ppx_runtime_deps:ppx_rt_deps ~
       ; requires ~preds lib_deps
       ]
     ; archives ~preds lib.name
-    ; [ exists_if (lib.name ^ ".cma") ]
     ; (match lib.kind with
        | Normal -> []
        | Ppx_rewriter | Ppx_deriver ->

--- a/src/jbuild_types.ml
+++ b/src/jbuild_types.ml
@@ -413,6 +413,7 @@ module Library = struct
     ; wrapped                  : bool
     ; optional                 : bool
     ; buildable                : Buildable.t
+    ; dynlink                  : bool
     }
 
   let v1 =
@@ -436,6 +437,7 @@ module Library = struct
        field      "wrapped" bool ~default:true                             >>= fun wrapped                  ->
        field_b    "optional"                                               >>= fun optional                 ->
        field      "self_build_stubs_archive" (option string) ~default:None >>= fun self_build_stubs_archive ->
+       field_b    "no_dynlink"                                             >>= fun no_dynlink               ->
        return
          { name
          ; public
@@ -457,6 +459,7 @@ module Library = struct
          ; wrapped
          ; optional
          ; buildable
+         ; dynlink = not no_dynlink
          })
 
   let vjs =
@@ -503,6 +506,7 @@ module Library = struct
          ; wrapped
          ; optional
          ; buildable
+         ; dynlink = true
          })
 
   let has_stubs t =


### PR DESCRIPTION
This PR adds `(no_dynlink)` field to libraries which disable the build of:

- the `.cmxs`
- the `.so` for the C stubs

It also passes the `-nodynlink` flag to `ocamlopt`, since there is no point in producing dynlinkable code.

/cc @LaurentMazare 
