### PR TITLE
[WIP] odoc rules

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -574,12 +574,6 @@ let rules =
        Build_system.build_rules setup.build_system targets ~recursive >>= fun rules ->
        let print oc =
          let ppf = Format.formatter_of_out_channel oc in
-         let get_action (rule : Build_system.Rule.t) =
-           if Path.is_root rule.action.dir then
-             rule.action.action
-           else
-             Chdir (rule.action.dir, rule.action.action)
-         in
          Sexp.prepare_formatter ppf;
          Format.pp_open_vbox ppf 0;
          if makefile_syntax then begin
@@ -591,7 +585,7 @@ let rules =
                (fun ppf ->
                   Path.Set.iter rule.deps ~f:(fun dep ->
                     Format.fprintf ppf "@ %s" (Path.to_string dep)))
-               Sexp.pp_split_strings (Action.Mini_shexp.sexp_of_t (get_action rule)))
+               Sexp.pp_split_strings (Action.Mini_shexp.sexp_of_t rule.action.action))
          end else begin
            List.iter rules ~f:(fun (rule : Build_system.Rule.t) ->
              let sexp =
@@ -603,7 +597,7 @@ let rules =
                    ; (match rule.action.context with
                       | None -> []
                       | Some c -> ["context", Atom c.name])
-                   ; [ "action" , Action.Mini_shexp.sexp_of_t (get_action rule) ]
+                   ; [ "action" , Action.Mini_shexp.sexp_of_t rule.action.action ]
                    ])
              in
              Format.fprintf ppf "%a@," Sexp.pp_split_strings sexp)

--- a/doc/api-doc.rst
+++ b/doc/api-doc.rst
@@ -1,0 +1,45 @@
+*****************
+API documentation
+*****************
+
+Jbuilder supports generating API documentation for libraries using the
+`odoc tool <https://github.com/ocaml-doc/odoc>`__ in HTML format.
+
+For this to work you need to have odoc installed and have
+documentation comments in your OCaml source files following the syntax
+described in the the section ``Text formatting`` of the `OCaml manual
+<http://caml.inria.fr/pub/docs/manual-ocaml/ocamldoc.html>`_.
+
+Generated pages
+===============
+
+Jbuilder stores the generated HTML pages in
+``_build/<context>/_doc`. It creates one sub-directory per public
+library and generates an ``index.html`` file in each sub-directory.
+
+The documentation is never installed on the system by Jbuilder. It is
+meant to be read locally while developping and then published on the
+www when releasing packages.
+
+Building the documentation
+==========================
+
+To build the documentaion, you can simply use the ``doc`` alias, which
+depends on the generated HTML pages for all the public libraries.
+
+For instance:
+
+.. code:: bash
+
+    $ jbuilder build @doc
+
+Custom library indexes
+======================
+
+If the directory where a library lives contains a file named
+``<lib-name>.mld``, Jbuilder will generate the library index from this
+file. ``<lib-name>`` is what you put in the ``(name ...)`` field of the
+library's jbuild file.
+
+Such a file must contains text using the same syntax as ocamldoc
+comments.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,5 +14,6 @@ Welcome to jbuilder's documentation!
    terminology
    project-layout-specification
    jbuild
+   api-doc
    usage
    advanced-topics

--- a/doc/terminology.rst
+++ b/doc/terminology.rst
@@ -40,3 +40,5 @@ Terminology
 
    -  ``runtest`` which runs user defined tests
    -  ``install`` which depends on everything that should be installed
+   -  ``doc``     which depends on the generated HTML
+      documentation. See :ref:`apidoc` for details

--- a/src/action.mli
+++ b/src/action.mli
@@ -30,6 +30,7 @@ module Mini_shexp : sig
       | Bash           of 'a
       | Update_file    of 'path * 'a
       | Rename         of 'path * 'path
+      | Remove_tree    of 'path
     val t : 'a Sexp.Of_sexp.t -> 'b Sexp.Of_sexp.t -> ('a, 'b) t Sexp.Of_sexp.t
     val sexp_of_t : 'a Sexp.To_sexp.t -> 'b Sexp.To_sexp.t -> ('a, 'b) t Sexp.To_sexp.t
   end

--- a/src/action.mli
+++ b/src/action.mli
@@ -41,6 +41,9 @@ module Mini_shexp : sig
   (** Return the list of files under an [Update_file] *)
   val updated_files : t -> Path.Set.t
 
+  (** Return the list of directories the action chdirs to *)
+  val chdirs : t -> Path.Set.t
+
   module Unexpanded : sig
     type desc = t
     type t = (String_with_vars.t, String_with_vars.t) Ast.t
@@ -53,7 +56,6 @@ end
 
 type t =
   { context : Context.t option
-  ; dir     : Path.t
   ; action  : Mini_shexp.t
   }
 

--- a/src/alias.ml
+++ b/src/alias.ml
@@ -44,11 +44,13 @@ let file_with_digest_suffix t ~digest =
 let default = make "DEFAULT"
 let runtest = make "runtest"
 let install = make "install"
+let doc     = make "doc"
 
 let recursive_aliases =
   [ default
   ; runtest
   ; install
+  ; doc
   ]
 
 module Store = struct

--- a/src/alias.mli
+++ b/src/alias.mli
@@ -5,6 +5,7 @@ val make : string -> dir:Path.t -> t
 val default : dir:Path.t -> t
 val runtest : dir:Path.t -> t
 val install : dir:Path.t -> t
+val doc     : dir:Path.t -> t
 
 val dep : t -> ('a, 'a) Build.t
 val file : t -> Path.t

--- a/src/build.ml
+++ b/src/build.ml
@@ -254,6 +254,10 @@ let symlink ~src ~dst =
 let create_file fn =
   action_context_independent ~targets:[fn] (Create_file fn)
 
+let remove_tree dir =
+  arr (fun _ ->
+    { Action. context = None; action = Remove_tree dir })
+
 let progn ts =
   all ts >>^ fun (actions : Action.t list) ->
   let rec loop context acc actions =

--- a/src/build.ml
+++ b/src/build.ml
@@ -229,7 +229,7 @@ let action_context_independent ?dir ~targets action =
     | Some dir -> Chdir (dir, action)
   in
   Targets targets
-  >>^ fun () ->
+  >>^ fun _ ->
   { Action. context = None; action  }
 
 let update_file fn s =

--- a/src/build.mli
+++ b/src/build.mli
@@ -116,7 +116,7 @@ val copy : src:Path.t -> dst:Path.t -> (unit, Action.t) t
 
 val symlink : src:Path.t -> dst:Path.t -> (unit, Action.t) t
 
-val create_file : Path.t -> (unit, Action.t) t
+val create_file : Path.t -> (_, Action.t) t
 
 (** Merge a list of actions *)
 val progn : ('a, Action.t) t list -> ('a, Action.t) t

--- a/src/build.mli
+++ b/src/build.mli
@@ -118,7 +118,8 @@ val symlink : src:Path.t -> dst:Path.t -> (unit, Action.t) t
 
 val create_file : Path.t -> (unit, Action.t) t
 
-val and_create_file : Path.t -> (Action.t, Action.t) t
+(** Merge a list of actions *)
+val progn : ('a, Action.t) t list -> ('a, Action.t) t
 
 type lib_dep_kind =
   | Optional

--- a/src/build.mli
+++ b/src/build.mli
@@ -117,6 +117,7 @@ val copy : src:Path.t -> dst:Path.t -> (unit, Action.t) t
 val symlink : src:Path.t -> dst:Path.t -> (unit, Action.t) t
 
 val create_file : Path.t -> (_, Action.t) t
+val remove_tree : Path.t -> (_, Action.t) t
 
 (** Merge a list of actions *)
 val progn : ('a, Action.t) t list -> ('a, Action.t) t

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -272,7 +272,6 @@ module Build_exec = struct
         file.data <- Some x;
         { Action.
           context = None
-        ; dir     = Path.root
         ; action  = Update_file (fn, vfile_to_string kind fn x)
         }
       | Compose (a, b) ->
@@ -371,14 +370,15 @@ let () =
     pending_targets := Pset.empty;
     Pset.iter fns ~f:Path.unlink_no_err)
 
-let make_local_dir t path =
-  match Path.kind path with
-  | Local path ->
-    if not (Path.Local.Set.mem path t.local_mkdirs) then begin
-      Path.Local.mkdir_p path;
-      t.local_mkdirs <- Path.Local.Set.add path t.local_mkdirs
-    end
-  | _ -> ()
+let make_local_dirs t paths =
+  Pset.iter paths ~f:(fun path ->
+    match Path.kind path with
+    | Local path ->
+      if not (Path.Local.Set.mem path t.local_mkdirs) then begin
+        Path.Local.mkdir_p path;
+        t.local_mkdirs <- Path.Local.Set.add path t.local_mkdirs
+      end
+    | _ -> ())
 
 let make_local_parent_dirs t paths ~map_path =
   Pset.iter paths ~f:(fun path ->
@@ -488,7 +488,7 @@ let compile_rule t ~all_targets_by_dir ?(allow_override=false) pre_rule =
         | None ->
           action
       in
-      make_local_dir t action.dir;
+      make_local_dirs t (Action.Mini_shexp.chdirs action.action);
       Action.exec ~targets action >>| fun () ->
       Option.iter sandbox_dir ~f:Path.rm_rf;
       (* All went well, these targets are no longer pending *)

--- a/src/config.ml
+++ b/src/config.ml
@@ -16,3 +16,5 @@ let local_install_lib_dir ~context ~package =
     package
 
 let dev_null = Path.of_string (if Sys.win32 then "nul" else "/dev/null")
+
+let jbuilder_keep_fname = ".jbuilder-keep"

--- a/src/config.mli
+++ b/src/config.mli
@@ -11,3 +11,6 @@ val local_install_lib_dir : context:string -> package:string -> Path.t
 
 val dev_null : Path.t
 
+(** When this file is present in a directory jbuilder will delete
+    nothing in it if it knows to generate this file. *)
+val jbuilder_keep_fname : string

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -512,7 +512,9 @@ module Gen(P : Params) = struct
          Build.create_file digest_path
        | Some action ->
          deps
-         >>> SC.Action.run
+         >>>
+         Build.progn
+           [ SC.Action.run
                sctx
                action
                ~dir
@@ -520,8 +522,8 @@ module Gen(P : Params) = struct
                ~targets:[]
                ~deps:(SC.Deps.only_plain_files sctx ~dir alias_conf.deps)
                ~package_context
-         >>>
-         Build.and_create_file digest_path)
+           ; Build.create_file digest_path
+           ])
 
   (* +-----------------------------------------------------------------+
      | Modules listing                                                 |

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -365,6 +365,9 @@ module Gen(P : Params) = struct
         SC.add_rule sctx build
       );
 
+    (* Odoc *)
+    Odoc.setup_library_rules sctx lib ~dir ~requires ~modules ~dep_graph;
+
     let flags =
       match alias_module with
       | None -> flags.common
@@ -629,6 +632,7 @@ module Gen(P : Params) = struct
   let () = List.iter (SC.stanzas sctx) ~f:rules
   let () =
     SC.add_rules sctx (Js_of_ocaml_rules.setup_separate_compilation_rules sctx)
+  let () = Odoc.setup_css_rule sctx
 
   (* +-----------------------------------------------------------------+
      | META                                                            |

--- a/src/module.ml
+++ b/src/module.ml
@@ -46,3 +46,10 @@ let cmt_file t ~dir (kind : Ml_kind.t) =
   match kind with
   | Impl -> Some (Path.relative dir (t.obj_name ^ ".cmt"))
   | Intf -> Option.map t.intf ~f:(fun _ -> Path.relative dir (t.obj_name ^ ".cmti"))
+
+let odoc_file t ~dir = Path.relative dir (t.obj_name ^ ".odoc")
+
+let cmti_file t ~dir =
+  match t.intf with
+  | None   -> Path.relative dir (t.obj_name ^ ".cmt")
+  | Some _ -> Path.relative dir (t.obj_name ^ ".cmti")

--- a/src/module.mli
+++ b/src/module.mli
@@ -30,3 +30,8 @@ val file      : t -> dir:Path.t -> Ml_kind.t -> Path.t option
 val cm_source : t -> dir:Path.t -> Cm_kind.t -> Path.t option
 val cm_file   : t -> dir:Path.t -> Cm_kind.t -> Path.t
 val cmt_file  : t -> dir:Path.t -> Ml_kind.t -> Path.t option
+
+val odoc_file : t -> dir:Path.t -> Path.t
+
+(** Either the .cmti, or .cmt if the module has no interface *)
+val cmti_file : t -> dir:Path.t -> Path.t

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -44,13 +44,13 @@ let compile_module sctx (m : Module.t) ~odoc ~dir ~includes ~dep_graph ~modules
   (m, odoc_file)
 
 let to_html sctx (m : Module.t) odoc_file ~doc_dir ~odoc ~dir ~includes
-      ~dep_graph ~modules ~lib_public_name =
+      ~lib_public_name ~(lib : Library.t) =
   let context = SC.context sctx in
   let html_file =
-    doc_dir ++ lib_public_name ++ m.name ++ "index.html"
+    doc_dir ++ lib_public_name ++ String.capitalize m.obj_name ++ "index.html"
   in
   SC.add_rule sctx
-    (module_deps m ~dir ~dep_graph ~modules
+    (Alias.dep (Alias.lib_odoc_all ~dir lib.name)
      >>>
      includes
      >>>
@@ -147,6 +147,7 @@ let setup_library_rules sctx (lib : Library.t) ~dir ~modules ~requires
     Alias.add_deps aliases (Alias.lib_odoc_all ~dir lib.name)
       (List.map modules_and_odoc_files ~f:snd);
     let doc_dir = doc_dir ++ context.name in
+    (*
     let modules_and_odoc_files =
       if lib.wrapped then
         let main_module_name = String.capitalize_ascii lib.name in
@@ -154,10 +155,10 @@ let setup_library_rules sctx (lib : Library.t) ~dir ~modules ~requires
           ~f:(fun (m, _) -> m.Module.name = main_module_name)
       else
         modules_and_odoc_files
-    in
+       in*)
     let html_files =
       List.map modules_and_odoc_files ~f:(fun (m, odoc_file) ->
-        to_html sctx m odoc_file ~doc_dir ~odoc ~dir ~includes ~dep_graph ~modules
+        to_html sctx m odoc_file ~doc_dir ~odoc ~dir ~includes ~lib
           ~lib_public_name:public.name)
     in
     let lib_index_html =

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -47,7 +47,8 @@ let to_html sctx (m : Module.t) odoc_file ~doc_dir ~odoc ~dir ~includes
      includes
      >>>
      Build.progn
-       [ Build.run ~context ~dir odoc ~extra_targets:[html_file]
+       [ Build.remove_tree html_dir
+       ; Build.run ~context ~dir odoc ~extra_targets:[html_file]
            [ A "html"
            ; Dyn (fun x -> x)
            ; A "-I"; Path dir

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -1,0 +1,126 @@
+open Import
+open Jbuild_types
+open Build.O
+
+module SC = Super_context
+
+let ( ++ ) = Path.relative
+
+let get_odoc sctx = SC.resolve_program sctx "odoc" ~hint:"opam install odoc"
+
+let lib_odoc_all ~dir (lib : Library.t)  =
+  Alias.file (Alias.lib_odoc_all ~dir lib.name)
+
+let lib_dependencies (libs : Lib.t list) =
+  List.filter_map libs ~f:(function
+    | External _ -> None
+    | Internal (dir, lib) -> Some (lib_odoc_all ~dir lib))
+
+let module_deps (m : Module.t) ~dir ~dep_graph ~modules =
+  Build.dyn_paths
+    (dep_graph
+     >>^ fun graph ->
+     List.map (Utils.find_deps ~dir graph m.name)
+       ~f:(fun name ->
+         let m = Utils.find_module ~dir modules name in
+         Module.odoc_file m ~dir))
+
+let compile_module sctx (m : Module.t) ~odoc ~dir ~includes ~dep_graph ~modules
+      ~lib_public_name =
+  let context = SC.context sctx in
+  let odoc_file = Module.odoc_file m ~dir in
+  SC.add_rule sctx
+    (module_deps m ~dir ~dep_graph ~modules
+     >>>
+     includes
+     >>>
+     Build.run ~context ~dir odoc ~extra_targets:[odoc_file]
+       [ A "compile"
+       ; Dyn (fun x -> x)
+       ; A "-I"; Path dir
+       ; As ["--pkg"; lib_public_name]
+       ; Dep (Module.cmti_file m ~dir)
+       ]);
+  (m, odoc_file)
+
+let to_html sctx (m : Module.t) odoc_file ~doc_dir ~odoc ~dir ~includes
+      ~dep_graph ~modules ~lib_public_name =
+  let context = SC.context sctx in
+  let html_file =
+    doc_dir ++ lib_public_name ++ m.name ++ "index.html"
+  in
+  SC.add_rule sctx
+    (module_deps m ~dir ~dep_graph ~modules
+     >>>
+     includes
+     >>>
+     Build.run ~context ~dir odoc ~extra_targets:[html_file]
+       [ A "html"
+       ; Dyn (fun x -> x)
+       ; A "-I"; Path dir
+       ; A "-o"; Path doc_dir
+       ; Dep odoc_file
+       ]);
+  html_file
+
+let doc_dir = Path.of_string "_build/doc"
+
+let css_file sctx =
+  let context = SC.context sctx in
+  doc_dir ++ context.name ++ "odoc.css"
+
+let setup_library_rules sctx (lib : Library.t) ~dir ~modules ~requires
+      ~(dep_graph:Ocamldep.dep_graph) =
+  Option.iter lib.public ~f:(fun public ->
+    let context = SC.context sctx in
+    let dep_graph =
+      (* Use the dependency graph given by ocamldep. However, when a module has no .mli,
+         use the dependencies for the .ml *)
+      Build.fanout dep_graph.intf dep_graph.impl
+      >>^ fun (intf, impl) ->
+      String_map.merge intf impl ~f:(fun _ intf impl ->
+        match intf, impl with
+        | Some _, _    -> intf
+        | None, Some _ -> impl
+        | None, None -> assert false)
+    in
+    let odoc = get_odoc sctx in
+    let includes =
+      requires
+      >>>
+      Build.dyn_paths (Build.arr lib_dependencies)
+      >>^ Lib.include_flags
+    in
+    let odoc_files =
+      List.map (String_map.values modules)
+        ~f:(compile_module sctx ~odoc ~dir ~includes ~dep_graph ~modules
+              ~lib_public_name:public.name)
+    in
+    let aliases = SC.aliases sctx in
+    Alias.add_deps aliases (Alias.lib_odoc_all ~dir lib.name)
+      (List.map odoc_files ~f:snd);
+    let doc_dir = doc_dir ++ context.name in
+    let odoc_files =
+      if lib.wrapped then
+        let main_module_name = String.capitalize_ascii lib.name in
+        List.filter odoc_files ~f:(fun (m, _) -> m.Module.name = main_module_name)
+      else
+        odoc_files
+    in
+    let html_files =
+      List.map odoc_files ~f:(fun (m, odoc_file) ->
+        to_html sctx m odoc_file ~doc_dir ~odoc ~dir ~includes ~dep_graph ~modules
+          ~lib_public_name:public.name)
+    in
+    Alias.add_deps aliases (Alias.doc ~dir) (css_file sctx :: html_files))
+
+let setup_css_rule sctx =
+  let context = SC.context sctx in
+  let doc_dir = doc_dir ++ context.name in
+  SC.add_rule sctx
+    (Build.run ~context
+       ~dir:context.build_dir
+       ~extra_targets:[doc_dir ++ "odoc.css"]
+       (get_odoc sctx)
+       [ A "css"; A "-o"; Path doc_dir ]);
+

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -39,21 +39,24 @@ let compile_module sctx (m : Module.t) ~odoc ~dir ~includes ~dep_graph ~modules
 let to_html sctx (m : Module.t) odoc_file ~doc_dir ~odoc ~dir ~includes
       ~lib_public_name ~(lib : Library.t) =
   let context = SC.context sctx in
-  let html_file =
-    doc_dir ++ lib_public_name ++ String.capitalize m.obj_name ++ "index.html"
-  in
+  let html_dir = doc_dir ++ lib_public_name ++ String.capitalize m.obj_name in
+  let html_file = html_dir ++ "index.html" in
   SC.add_rule sctx
     (SC.Libs.static_file_deps (dir, lib) ~ext:odoc_ext
      >>>
      includes
      >>>
-     Build.run ~context ~dir odoc ~extra_targets:[html_file]
-       [ A "html"
-       ; Dyn (fun x -> x)
-       ; A "-I"; Path dir
-       ; A "-o"; Path doc_dir
-       ; Dep odoc_file
-       ]);
+     Build.progn
+       [ Build.run ~context ~dir odoc ~extra_targets:[html_file]
+           [ A "html"
+           ; Dyn (fun x -> x)
+           ; A "-I"; Path dir
+           ; A "-o"; Path doc_dir
+           ; Dep odoc_file
+           ]
+       ; Build.create_file (html_dir ++ Config.jbuilder_keep_fname)
+       ]
+    );
   html_file
 
 let lib_index sctx ~odoc ~dir ~(lib : Library.t) ~lib_public_name ~doc_dir ~modules

--- a/src/odoc.mli
+++ b/src/odoc.mli
@@ -1,0 +1,15 @@
+(** Odoc rules *)
+
+open Import
+open Jbuild_types
+
+val setup_library_rules
+  :  Super_context.t
+  -> Library.t
+  -> dir:Path.t
+  -> modules:Module.t String_map.t
+  -> requires:(unit, Lib.t list) Build.t
+  -> dep_graph:Ocamldep.dep_graph
+  -> unit
+
+val setup_css_rule : Super_context.t -> unit

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -380,6 +380,9 @@ module Libs = struct
           end
         | Internal lib ->
           Alias.file (lib_files_alias lib ~ext) :: acc)))
+
+  let static_file_deps ~ext lib =
+    Alias.dep (lib_files_alias lib ~ext)
 end
 
 module Deps = struct

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -100,6 +100,9 @@ module Libs : sig
       extension [ext] of the libraries given as input. *)
   val file_deps : t -> ext:string -> (Lib.t list, Lib.t list) Build.t
 
+  (** Same as [file_deps] but for a single known library *)
+  val static_file_deps : ext:string -> Lib.Internal.t -> ('a, 'a) Build.t
+
   (** Setup the alias that depends on all files with a given extension for a library *)
   val setup_file_deps_alias : t -> Lib.Internal.t -> ext:string -> Path.t list -> unit
 


### PR DESCRIPTION
This adds the `@doc` alias to build documentation of public libraries. The doc is stored in `_build/doc/<context-name>`.

- [x] : odoc compilation rules
- [x] : generate indexes for libraries
- [ ] : ~~generate a global index~~
- [ ] : add a `doc` command, that build the `@doc` aliases
- [x] : document the feature