### PR TITLE
Ignore local switch directory

### DIFF
--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -37,6 +37,7 @@ let root t = t.root
 
 let ignore_file = function
   | ""
+  | "_opam"
   | "_build"
   | ".git"
   | ".hg"


### PR DESCRIPTION
This makes jbuilder usable for building projects that use a local switch