### PR TITLE
Fix small typo in quickstart

### DIFF
--- a/doc/quick-start.rst
+++ b/doc/quick-start.rst
@@ -122,7 +122,7 @@ Add this field to your ``library`` or ``executables`` stanzas:
 
     (preprocess (action (run ${bin:cppo} -V OCAML:${ocaml_version} ${<})))
 
-Additionnaly, if you are include a ``config.h`` file, you need to
+Additionally, if you are include a ``config.h`` file, you need to
 declare the dependency to this file via:
 
 .. code:: scheme


### PR DESCRIPTION
Great to see actual docs for Jane Street projects, so I thought I might try my luck contributing.

I was also a bit confused by the `.exe` thing on Unix, maybe I'll make another PR to clear that up.