### PR TITLE
  Add ocaml_release, ocaml_patch and ocaml_revision 

### DIFF
--- a/doc/jbuild.rst
+++ b/doc/jbuild.rst
@@ -529,6 +529,12 @@ Jbuilder supports the following variables:
 -  ``OCAMLOPT`` is the ``ocamlopt`` binary
 -  ``ocaml_version`` is the version of the compiler used in the
    current build context
+-  ``ocaml_release`` is the major and minor version of the compiler used in the
+   current build context (e.g. ``4.04``)
+-  ``ocaml_patch`` is the additional-info portion of the version string of the
+   compiler used in the current build context (e.g. ``dev8-2017-03-20``)
+-  ``ocaml_revision`` is the patch-level/revision number of the compiler used in
+   the current build context (e.g. ``1`` for ``4.04.1``)
 -  ``ocaml_where`` is the output of ``ocamlc -where``
 -  ``ARCH_SIXTYFOUR`` is ``true`` if using a compiler targeting a
    64 bit architecture and ``false`` otherwise

--- a/src/import.ml
+++ b/src/import.ml
@@ -371,6 +371,11 @@ module Option = struct
     | Some x -> x
     | None -> assert false
 
+  let value_map o ~default ~f =
+    match o with
+    | Some x -> f x
+    | None   -> default
+
   let some_if cond x =
     if cond then Some x else None
 

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -163,6 +163,18 @@ let create
       | None   -> "make"
       | Some p -> Path.to_string p
     in
+    let (ocaml_release, ocaml_patch, ocaml_revision) =
+      let last_dot = String.rindex context.version '.' in
+      let len = String.length context.version in
+      let plus = String.index context.version '+' in
+      let f ~len n =
+        let pos = succ n in
+        String.sub context.version ~pos ~len:(len - pos)
+      in
+      String.sub context.version ~pos:0 ~len:last_dot,
+      Option.value_map plus ~default:"" ~f:(f ~len),
+      f ~len:(Option.value plus ~default:len) last_dot
+    in
     [ "-verbose"       , "" (*"-verbose";*)
     ; "CPP"            , sprintf "%s %s -E" context.c_compiler context.ocamlc_cflags
     ; "PA_CPP"         , sprintf "%s %s -undef -traditional -x c -E" context.c_compiler
@@ -174,6 +186,9 @@ let create
     ; "OCAMLC"         , Path.to_string context.ocamlc
     ; "OCAMLOPT"       , Path.to_string ocamlopt
     ; "ocaml_version"  , context.version
+    ; "ocaml_release"  , ocaml_release
+    ; "ocaml_patch"    , ocaml_patch
+    ; "ocaml_revision" , ocaml_revision
     ; "ocaml_where"    , Path.to_string context.stdlib_dir
     ; "ARCH_SIXTYFOUR" , string_of_bool context.arch_sixtyfour
     ; "MAKE"           , make


### PR DESCRIPTION
Adds a few more variables based on ocaml_version.

The original motivation was to be able to get the main OCaml version (4.02, 4.03, etc.) for use in rules picking up compatibility layers.