### PR TITLE
Remove spurious C compiler warning on MSVC

### DIFF
--- a/src/context.ml
+++ b/src/context.ml
@@ -459,3 +459,9 @@ let best_mode t : Mode.t =
   match t.ocamlopt with
   | Some _ -> Native
   | None   -> Byte
+
+let cc_g (ctx : t) =
+  if !Clflags.g && ctx.ccomp_type <> "msvc" then
+    ["-g"]
+  else
+    []

--- a/src/context.mli
+++ b/src/context.mli
@@ -154,3 +154,6 @@ val compiler : t -> Mode.t -> Path.t option
 
 (** The best compilation mode for this context *)
 val best_mode : t -> Mode.t
+
+(** [\["-g"\]] if [!Clflags.g] and [\[\]] otherwise *)
+val cc_g : t -> string list

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -100,7 +100,7 @@ module Gen(P : Params) = struct
       (Build.paths h_files
        >>>
        Build.fanout
-         (SC.expand_and_eval_set ~dir lib.c_flags ~standard:(Utils.g ()))
+         (SC.expand_and_eval_set ~dir lib.c_flags ~standard:(Context.cc_g ctx))
          requires
        >>>
        Build.run ~context:ctx
@@ -125,7 +125,7 @@ module Gen(P : Params) = struct
       (Build.paths h_files
        >>>
        Build.fanout
-         (SC.expand_and_eval_set ~dir lib.cxx_flags ~standard:(Utils.g ()))
+         (SC.expand_and_eval_set ~dir lib.cxx_flags ~standard:(Context.cc_g ctx))
          requires
        >>>
        Build.run ~context:ctx


### PR DESCRIPTION
The Microsoft C compiler doesn't recognise `-g`. For now, easier just not to compile with any debugging information on MSVC.