### PR TITLE
docs: remove an extra set of brackets from the `select ... from`

### DIFF
--- a/doc/jbuild.rst
+++ b/doc/jbuild.rst
@@ -660,9 +660,9 @@ Select forms are specified as follows:
 .. code:: scheme
 
     (select <target-filename> from
-      ((<literals> -> <filename>)
-       (<literals> -> <filename>)
-       ...))
+      (<literals> -> <filename>)
+      (<literals> -> <filename>)
+       ...)
 
 ``<literals>`` are lists of literals, where each literal is one of:
 


### PR DESCRIPTION
Looks like the right syntax is `(select foo from (x -> y) ( -> y))`
from the example use in js_of_ocaml/compiler