### PR TITLE
Automatically install executable with extension `.exe` on Windows

### DIFF
--- a/doc/jbuild.rst
+++ b/doc/jbuild.rst
@@ -487,6 +487,18 @@ instance, to install a file ``mylib.el`` as
   package is not ambiguous when the first parent directory to contain a
   ``<package>.opam`` file contains exactly one ``<package>.opam`` file
 
+Handling of the .exe extension on Windows
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Under Microsoft Windows, executables must be suffixed with
+``.exe``. Jbuilder tries to make sure that executables are always
+installed with this extension on Windows.
+
+More precisely, when installing a file via an ``(install ...)``
+stanza, if the source file has extension ``.exe`` or ``.bc``, then
+Jbuilder implicitly adds the ``.exe`` extension to the destination, if
+not already present.
+
 Common items
 ============
 

--- a/src/action.ml
+++ b/src/action.ml
@@ -479,34 +479,34 @@ let fold_one_step t ~init:acc ~f =
   | Mkdir _ -> acc
 
 let rec map t ~fs ~fp =
-    match t with
-    | Run (This prog, args) ->
-      Run (This (fp prog), List.map args ~f:fs)
-    | Run (Not_found _ as nf, args) ->
-      Run (nf, List.map args ~f:fs)
-    | Chdir (fn, t) ->
-      Chdir (fp fn, map t ~fs ~fp)
-    | Setenv (var, value, t) ->
-      Setenv (fs var, fs value, map t ~fs ~fp)
-    | Redirect (outputs, fn, t) ->
-      Redirect (outputs, fp fn, map t ~fs ~fp)
-    | Ignore (outputs, t) ->
-      Ignore (outputs, map t ~fs ~fp)
-    | Progn l -> Progn (List.map l ~f:(fun t -> map t ~fs ~fp))
-    | Echo x -> Echo (fs x)
-    | Cat x -> Cat (fp x)
-    | Create_file x -> Create_file (fp x)
-    | Copy (x, y) -> Copy (fp x, fp y)
-    | Symlink (x, y) ->
-      Symlink (fp x, fp y)
-    | Copy_and_add_line_directive (x, y) ->
-      Copy_and_add_line_directive (fp x, fp y)
-    | System x -> System (fs x)
-    | Bash x -> Bash (fs x)
-    | Update_file (x, y) -> Update_file (fp x, fs y)
-    | Rename (x, y) -> Rename (fp x, fp y)
-    | Remove_tree x -> Remove_tree (fp x)
-    | Mkdir x -> Mkdir (fp x)
+  match t with
+  | Run (This prog, args) ->
+    Run (This (fp prog), List.map args ~f:fs)
+  | Run (Not_found _ as nf, args) ->
+    Run (nf, List.map args ~f:fs)
+  | Chdir (fn, t) ->
+    Chdir (fp fn, map t ~fs ~fp)
+  | Setenv (var, value, t) ->
+    Setenv (fs var, fs value, map t ~fs ~fp)
+  | Redirect (outputs, fn, t) ->
+    Redirect (outputs, fp fn, map t ~fs ~fp)
+  | Ignore (outputs, t) ->
+    Ignore (outputs, map t ~fs ~fp)
+  | Progn l -> Progn (List.map l ~f:(fun t -> map t ~fs ~fp))
+  | Echo x -> Echo (fs x)
+  | Cat x -> Cat (fp x)
+  | Create_file x -> Create_file (fp x)
+  | Copy (x, y) -> Copy (fp x, fp y)
+  | Symlink (x, y) ->
+    Symlink (fp x, fp y)
+  | Copy_and_add_line_directive (x, y) ->
+    Copy_and_add_line_directive (fp x, fp y)
+  | System x -> System (fs x)
+  | Bash x -> Bash (fs x)
+  | Update_file (x, y) -> Update_file (fp x, fs y)
+  | Rename (x, y) -> Rename (fp x, fp y)
+  | Remove_tree x -> Remove_tree (fp x)
+  | Mkdir x -> Mkdir (fp x)
 
 let updated_files =
   let rec loop acc t =

--- a/src/artifacts.ml
+++ b/src/artifacts.ml
@@ -3,13 +3,14 @@ open Jbuild
 
 type t =
   { context    : Context.t
-  ; local_bins : String_set.t
+  ; local_bins : Path.t String_map.t
   ; local_libs : Public_lib.t String_map.t
   }
 
-let create context l ~f =
+let create (context : Context.t) l ~f =
+  let bin_dir = Config.local_install_bin_dir ~context:context.name in
   let local_bins, local_libs =
-    List.fold_left l ~init:(String_set.empty, String_map.empty)
+    List.fold_left l ~init:(String_map.empty, String_map.empty)
       ~f:(fun acc x ->
         List.fold_left (f x) ~init:acc
           ~f:(fun (local_bins, local_libs) stanza ->
@@ -22,7 +23,28 @@ let create context l ~f =
                      | Some s -> s
                      | None -> Filename.basename src
                    in
-                   String_set.add name acc),
+                   let key =
+                     if Sys.win32 && Filename.extension name = ".exe" then
+                       String.sub name ~pos:0 ~len:(String.length name - 4)
+                     else
+                       name
+                   in
+                   let in_bin_dir =
+                     let fn =
+                       if Sys.win32 then
+                         match Filename.extension src with
+                         | ".exe" | ".bc" ->
+                           if Filename.extension name <> ".exe" then
+                             name ^ ".exe"
+                           else
+                             name
+                         | _ -> name
+                       else
+                         name
+                     in
+                     Path.relative bin_dir fn
+                   in
+                   String_map.add acc ~key ~data:in_bin_dir),
                local_libs)
             | Library { public = Some pub; _ } ->
               (local_bins,
@@ -35,19 +57,13 @@ let create context l ~f =
   ; local_libs
   }
 
-let in_local_bin t name =
-  Path.relative (Config.local_install_bin_dir ~context:t.context.name) name
-
 let binary t ?hint ?(in_the_tree=true) name =
   if not (Filename.is_relative name) then
     Ok (Path.absolute name)
   else if in_the_tree then begin
-    let name_exe = if Sys.win32 then name ^ ".exe" else name in
-    if String_set.mem name_exe t.local_bins then
-      Ok (in_local_bin t name_exe)
-    else if Sys.win32 && String_set.mem name t.local_bins then
-      Ok (in_local_bin t name)
-    else
+    match String_map.find name t.local_bins with
+    | Some path -> Ok path
+    | None ->
       match Context.which t.context name with
       | Some p -> Ok p
       | None ->

--- a/src/artifacts.mli
+++ b/src/artifacts.mli
@@ -27,6 +27,7 @@ val binary
 *)
 val file_of_lib
   :  t
+  -> loc:Loc.t
   -> from:Path.t
   -> string
   -> string * (Path.t, fail) result

--- a/src/bin.mli
+++ b/src/bin.mli
@@ -17,3 +17,4 @@ val best_prog : Path.t -> string -> Path.t option
 
 (** "make" program *)
 val make : Path.t option
+

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -882,7 +882,7 @@ Add it to your jbuild file to remove this warning.
         Path.append install_dir (Install.Entry.relative_installed_path entry ~package)
       in
       SC.add_rule sctx (Build.symlink ~src:entry.src ~dst);
-      { entry with src = dst })
+      Install.Entry.set_src entry dst)
 
   let install_file package_path package entries =
     let entries =

--- a/src/install.ml
+++ b/src/install.ml
@@ -57,10 +57,30 @@ module Entry = struct
     }
 
   let make section ?dst src =
+    let dst =
+      if Sys.win32 then
+        let src_base = Path.basename src in
+        let dst' =
+          match dst with
+          | None -> src_base
+          | Some s -> s
+        in
+        match Filename.extension src_base with
+        | ".exe" | ".bc" ->
+          if Filename.extension dst' <> ".exe" then
+            Some (dst' ^ ".exe")
+          else
+            dst
+        | _ -> dst
+      else
+        dst
+    in
     { src
     ; dst
     ; section
     }
+
+  let set_src t src = { t with src }
 
   module Paths = struct
     let lib         = Path.(relative root) "lib"

--- a/src/install.mli
+++ b/src/install.mli
@@ -19,13 +19,14 @@ module Section : sig
 end
 
 module Entry : sig
-  type t =
+  type t = private
     { src     : Path.t
     ; dst     : string option
     ; section : Section.t
     }
 
   val make : Section.t -> ?dst:string -> Path.t -> t
+  val set_src : t -> Path.t -> t
 
   val relative_installed_path : t -> package:string -> Path.t
 end

--- a/src/js_of_ocaml_rules.ml
+++ b/src/js_of_ocaml_rules.ml
@@ -18,7 +18,7 @@ let in_build_dir ~ctx =
 
 let runtime_file ~sctx ~dir fname =
   let _lib, file =
-    Artifacts.file_of_lib (SC.artifacts sctx) ~from:dir
+    Artifacts.file_of_lib (SC.artifacts sctx) ~loc:Loc.none ~from:dir
       (sprintf "js_of_ocaml-compiler:%s" fname)
   in
   match file with

--- a/src/main.ml
+++ b/src/main.ml
@@ -203,6 +203,7 @@ let bootstrap () =
       ; "--subst"      , Unit subst                 , " substitute watermarks in source files"
       ]
       anon "Usage: boot.exe [-j JOBS] [--dev]\nOptions are:";
+    Clflags.debug_dep_path := true;
     let log = Log.create () in
     Future.Scheduler.go ~log
       (setup ~log ~workspace:{ merlin_context = Some "default"; contexts = [Default] }


### PR DESCRIPTION
When the user installs an executable, if the source file ends with `.bc` or `.exe`, jbuilder makes sure that the destination ends with `.exe`. This way executables that are installed in any section are correctly installed with the `.exe` suffix.

Additionally, Jbuilder now resolves `${libexec:<foo>:<file>}` to `<foo dir>/<file>.exe` if it exists, and `<foo dir>/<file>` otherwise.

@dra27, can you test this branch?