### PR TITLE
Various Windows tweaks

### DIFF
--- a/src/action.ml
+++ b/src/action.ml
@@ -537,7 +537,7 @@ let rec exec t ~ectx ~dir ~env_extra ~stdout_to ~stderr_to =
     return ()
   | Create_file fn ->
     let fn = Path.to_string fn in
-    if Sys.file_exists fn then Sys.remove fn;
+    if Sys.file_exists fn then Sys.force_remove fn;
     Unix.close (Unix.openfile fn [O_CREAT; O_TRUNC; O_WRONLY] 0o666);
     return ()
   | Copy (src, dst) ->

--- a/src/bin.mli
+++ b/src/bin.mli
@@ -8,6 +8,9 @@ val parse_path : string -> Path.t list
 (** The opam tool *)
 val opam : Path.t option
 
+(** Extension to append to executable filenames *)
+val exe : string
+
 (** Look for a program in the PATH *)
 val which : ?path:Path.t list -> string -> Path.t option
 

--- a/src/context.ml
+++ b/src/context.ml
@@ -311,7 +311,7 @@ let create ~(kind : Kind.t) ~path ~base_env ~env_extra ~name ~merlin ~use_findli
     ; toplevel_path = Option.map (get_env env "OCAML_TOPLEVEL_PATH") ~f:Path.absolute
 
     ; ocaml_bin  = dir
-    ; ocaml      = Path.relative dir "ocaml"
+    ; ocaml      = Path.relative dir ("ocaml" ^ Bin.exe)
     ; ocamlc
     ; ocamlopt   = best_prog "ocamlopt"
     ; ocamldep   = get_prog  "ocamldep"

--- a/src/future.ml
+++ b/src/future.ml
@@ -225,7 +225,7 @@ module Temp = struct
       let fns = !tmp_files in
       tmp_files := String_set.empty;
       String_set.iter fns ~f:(fun fn ->
-        try Sys.remove fn with _ -> ()))
+        try Sys.force_remove fn with _ -> ()))
 
   let create prefix suffix =
     let fn = Filename.temp_file prefix suffix in
@@ -233,7 +233,7 @@ module Temp = struct
     fn
 
   let destroy fn =
-    Sys.remove fn;
+    Sys.force_remove fn;
     tmp_files := String_set.remove fn !tmp_files
 end
 

--- a/src/future.ml
+++ b/src/future.ml
@@ -233,7 +233,7 @@ module Temp = struct
     fn
 
   let destroy fn =
-    Sys.force_remove fn;
+    (try Sys.force_remove fn with Sys_error _ -> ());
     tmp_files := String_set.remove fn !tmp_files
 end
 

--- a/src/import.ml
+++ b/src/import.ml
@@ -293,6 +293,22 @@ module String = struct
     loop 0 0 ~last_is_cr:false
 end
 
+module Sys = struct
+  include Sys
+
+  let force_remove =
+    if win32 then
+      fun fn ->
+        try
+          remove fn
+        with Sys_error _ ->
+          (* Try to remove the "read-only" attribute, then retry. *)
+          (try Unix.chmod fn 0o666 with Unix.Unix_error _ -> ());
+          remove fn
+    else
+      remove
+end
+
 module Filename = struct
   include Filename
 


### PR DESCRIPTION
Addresses @fdopen's patch referred to in #146. Three changes accepted:

1. Sys.remove replaced with Sys.force_remove which will attempt to remove the "read-only" attribute on Windows files
2. ocaml variable now includes the .exe extension on Windows
3. Context.Temp.destroy silently fails if it can't delete the file (as the at_exit routine does)

I have not merged the change to bash escaping for two reasons: firstly, this is better solved in the long-term using the `cygvoke` mechanism I've written for opam (but this needs to be spun into a library) and until a full solution is there, I think it better to keep discouraging the use of bash in actions anyway.

@diml - please could you give this a quick once-over?