### PR TITLE
Extend `(:include )` to anything that looks like a flag

### DIFF
--- a/doc/jbuild.rst
+++ b/doc/jbuild.rst
@@ -854,6 +854,7 @@ flags using the following fields:
 - ``(ocamlopt_flags <flags>)`` to specify flags passed to ``ocamlopt`` only
 
 For all these fields, ``<flags>`` is specified in the `Ordered set language`_.
+These fields all support ``(:include ...)`` forms.
 
 The default value for ``(flags ...)`` includes some ``-w`` options to set
 warnings. The exact set depends on whether ``--dev`` is passed to Jbuilder. As a

--- a/doc/jbuild.rst
+++ b/doc/jbuild.rst
@@ -874,7 +874,8 @@ using ``(js_of_ocaml (<js_of_ocaml-options>))``.
 
 ``<js_of_ocaml-options>`` are all optional:
 
-- ``(flags <flags>)`` to specify flags passed to ``js_of_ocaml``
+- ``(flags <flags>)`` to specify flags passed to ``js_of_ocaml``. This field
+  supports ``(:include ...)`` forms
 
 - ``(javascript_files (<files-list>))`` to specify ``js_of_ocaml`` JavaScript
   runtime files.

--- a/doc/jbuild.rst
+++ b/doc/jbuild.rst
@@ -226,6 +226,9 @@ binary at the same place as where ``ocamlc`` was found, or when there is a
 - ``(libraries (<library-dependencies>))`` specifies the library dependencies.
   See the section about `Library dependencies`_ for more details
 
+- ``(link_flags <flags>)`` specifies additional flags to pass to the linker.
+  This field supports ``(:include ...)`` forms
+
 - ``(modules <modules>)`` specifies which modules in the current directory
   Jbuilder should consider when building this executable. Modules not listed
   here will be ignored and cannot be used inside the executable described by

--- a/src/build.ml
+++ b/src/build.ml
@@ -122,6 +122,11 @@ let fanout3 a b c =
   (a &&& (b &&& c))
   >>>
   arr (fun (a, (b, c)) -> (a, b, c))
+let fanout4 a b c d =
+  let open O in
+  (a &&& (b &&& (c &&& d)))
+  >>>
+  arr (fun (a, (b, (c, d))) -> (a, b, c, d))
 
 let rec all = function
   | [] -> arr (fun _ -> [])

--- a/src/build.mli
+++ b/src/build.mli
@@ -30,6 +30,7 @@ val second : ('a, 'b) t -> ('c * 'a, 'c * 'b) t
     The default definition may be overridden with a more efficient version if desired. *)
 val fanout  : ('a, 'b) t -> ('a, 'c) t -> ('a, 'b * 'c) t
 val fanout3 : ('a, 'b) t -> ('a, 'c) t -> ('a, 'd) t ->  ('a, 'b * 'c * 'd) t
+val fanout4 : ('a, 'b) t -> ('a, 'c) t -> ('a, 'd) t -> ('a, 'e) t -> ('a, 'b * 'c * 'd * 'e) t
 
 val all : ('a, 'b) t list -> ('a, 'b list) t
 

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -275,7 +275,7 @@ module Gen(P : Params) = struct
          ~js_of_ocaml
         ~dynlink
         ~sandbox:alias_module_build_sandbox
-        ~flags:{ flags with common = flags.common @ ["-w"; "-49"] }
+        ~flags:(Ocaml_flags.append_common flags ["-w"; "-49"])
         ~dir
         ~modules:(String_map.singleton m.name m)
         ~dep_graph:(Ml_kind.Dict.make_both (Build.return (String_map.singleton m.name [])))
@@ -398,8 +398,8 @@ module Gen(P : Params) = struct
 
     let flags =
       match alias_module with
-      | None -> flags.common
-      | Some m -> "-open" :: m.name :: flags.common
+      | None -> Ocaml_flags.common flags
+      | Some m -> Ocaml_flags.prepend_common ["-open"; m.name] flags |> Ocaml_flags.common
     in
     { Merlin.
       requires = real_requires
@@ -498,7 +498,7 @@ module Gen(P : Params) = struct
           ~force_custom_bytecode:(mode = Native && not exes.modes.native)));
     { Merlin.
       requires   = real_requires
-    ; flags      = flags.common
+    ; flags      = Ocaml_flags.common flags
     ; preprocess = Buildable.single_preprocess exes.buildable
     ; libname    = None
     }

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -453,7 +453,12 @@ module Gen(P : Params) = struct
          ]);
     if mode = Mode.Byte then
       let rules = Js_of_ocaml_rules.build_exe sctx ~dir ~js_of_ocaml ~src:exe in
-      SC.add_rules sctx (List.map rules ~f:(fun r -> libs_and_cm >>> r))
+      let libs_and_cm_and_flags =
+        libs_and_cm
+        &&&
+        SC.expand_and_eval_set ~dir js_of_ocaml.flags ~standard:(Js_of_ocaml_rules.standard ())
+      in
+      SC.add_rules sctx (List.map rules ~f:(fun r -> libs_and_cm_and_flags >>> r))
 
   let executables_rules (exes : Executables.t) ~dir ~all_modules ~scope =
     let dep_kind = Build.Required in

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -533,7 +533,7 @@ module Library = struct
     ; c_names                  : string list
     ; cxx_flags                : Ordered_set_lang.Unexpanded.t
     ; cxx_names                : string list
-    ; library_flags            : String_with_vars.t list
+    ; library_flags            : Ordered_set_lang.Unexpanded.t
     ; c_library_flags          : Ordered_set_lang.Unexpanded.t
     ; self_build_stubs_archive : string option
     ; virtual_deps             : string list
@@ -555,7 +555,7 @@ module Library = struct
        field_oslu "cxx_flags"                                                >>= fun cxx_flags                ->
        field      "c_names" (list string) ~default:[]                        >>= fun c_names                  ->
        field      "cxx_names" (list string) ~default:[]                      >>= fun cxx_names                ->
-       field      "library_flags" (list String_with_vars.t) ~default:[]      >>= fun library_flags            ->
+       field_oslu "library_flags"                                            >>= fun library_flags            ->
        field_oslu "c_library_flags"                                          >>= fun c_library_flags          ->
        field      "virtual_deps" (list string) ~default:[]                   >>= fun virtual_deps             ->
        field      "modes" Mode.Dict.Set.t ~default:Mode.Dict.Set.all         >>= fun modes                    ->

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -310,27 +310,24 @@ module Lint = struct
       ]
 end
 
-let field_osl name =
-  field name Ordered_set_lang.t ~default:Ordered_set_lang.standard
-
 let field_oslu name =
   field name Ordered_set_lang.Unexpanded.t ~default:Ordered_set_lang.Unexpanded.standard
 
 module Js_of_ocaml = struct
 
   type t =
-    { flags            : Ordered_set_lang.t
+    { flags            : Ordered_set_lang.Unexpanded.t
     ; javascript_files : string list
     }
 
   let t =
     record
-      (field_osl "flags"                                      >>= fun flags ->
+      (field_oslu "flags"                                     >>= fun flags ->
        field     "javascript_files" (list string) ~default:[] >>= fun javascript_files ->
        return { flags; javascript_files })
 
   let default =
-    { flags = Ordered_set_lang.standard
+    { flags = Ordered_set_lang.Unexpanded.standard
     ; javascript_files = [] }
 end
 

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -444,9 +444,9 @@ module Buildable = struct
     ; libraries                : Lib_dep.t list
     ; preprocess               : Preprocess_map.t
     ; preprocessor_deps        : Dep_conf.t list
-    ; flags                    : Ordered_set_lang.t
-    ; ocamlc_flags             : Ordered_set_lang.t
-    ; ocamlopt_flags           : Ordered_set_lang.t
+    ; flags                    : Ordered_set_lang.Unexpanded.t
+    ; ocamlc_flags             : Ordered_set_lang.Unexpanded.t
+    ; ocamlopt_flags           : Ordered_set_lang.Unexpanded.t
     ; js_of_ocaml              : Js_of_ocaml.t
     }
 
@@ -464,9 +464,9 @@ module Buildable = struct
     >>= fun modules ->
     field "libraries" Lib_deps.t ~default:[]
     >>= fun libraries ->
-    field_osl "flags"          >>= fun flags          ->
-    field_osl "ocamlc_flags"   >>= fun ocamlc_flags   ->
-    field_osl "ocamlopt_flags" >>= fun ocamlopt_flags ->
+    field_oslu "flags"          >>= fun flags          ->
+    field_oslu "ocamlc_flags"   >>= fun ocamlc_flags   ->
+    field_oslu "ocamlopt_flags" >>= fun ocamlopt_flags ->
     field "js_of_ocaml" (Js_of_ocaml.t) ~default:Js_of_ocaml.default >>= fun js_of_ocaml ->
     return
       { preprocess

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -635,15 +635,15 @@ module Executables = struct
   type t =
     { names            : string list
     ; link_executables : bool
-    ; link_flags       : string list
+    ; link_flags       : Ordered_set_lang.Unexpanded.t
     ; modes            : Mode.Dict.Set.t
     ; buildable        : Buildable.t
     }
 
   let common_v1 pkgs names public_names ~multi =
     Buildable.v1 >>= fun buildable ->
-    field   "link_executables"   bool ~default:true >>= fun link_executables ->
-    field   "link_flags"         (list string) ~default:[] >>= fun link_flags ->
+    field      "link_executables"   bool ~default:true >>= fun link_executables ->
+    field_oslu "link_flags"                            >>= fun link_flags ->
     map_validate (field "modes" Mode.Dict.Set.t ~default:Mode.Dict.Set.all)
       ~f:(fun modes ->
         if Mode.Dict.Set.is_empty modes then

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -138,7 +138,7 @@ module Library : sig
     ; c_names                  : string list
     ; cxx_flags                : Ordered_set_lang.Unexpanded.t
     ; cxx_names                : string list
-    ; library_flags            : String_with_vars.t list
+    ; library_flags            : Ordered_set_lang.Unexpanded.t
     ; c_library_flags          : Ordered_set_lang.Unexpanded.t
     ; self_build_stubs_archive : string option
     ; virtual_deps             : string list

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -54,7 +54,7 @@ end
 
 module Js_of_ocaml : sig
   type t =
-    { flags            : Ordered_set_lang.t
+    { flags            : Ordered_set_lang.Unexpanded.t
     ; javascript_files : string list
     }
 end

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -170,7 +170,7 @@ module Executables : sig
   type t =
     { names            : string list
     ; link_executables : bool
-    ; link_flags       : string list
+    ; link_flags       : Ordered_set_lang.Unexpanded.t
     ; modes            : Mode.Dict.Set.t
     ; buildable        : Buildable.t
     }

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -100,9 +100,9 @@ module Buildable : sig
     ; libraries                : Lib_dep.t list
     ; preprocess               : Preprocess_map.t
     ; preprocessor_deps        : Dep_conf.t list
-    ; flags                    : Ordered_set_lang.t
-    ; ocamlc_flags             : Ordered_set_lang.t
-    ; ocamlopt_flags           : Ordered_set_lang.t
+    ; flags                    : Ordered_set_lang.Unexpanded.t
+    ; ocamlc_flags             : Ordered_set_lang.Unexpanded.t
+    ; ocamlopt_flags           : Ordered_set_lang.Unexpanded.t
     ; js_of_ocaml              : Js_of_ocaml.t
     }
 

--- a/src/js_of_ocaml_rules.ml
+++ b/src/js_of_ocaml_rules.ml
@@ -89,12 +89,12 @@ let link_rule ~sctx ~dir ~runtime ~target =
     ; Arg_spec.Dyn get_all
     ]
 
-let build_cm sctx ~dir ~js_of_ocaml ~src =
+let build_cm sctx ~scope ~dir ~js_of_ocaml ~src =
   if separate_compilation_enabled ()
   then let target = Path.extend_basename src ~suffix:".js" in
     let spec = Arg_spec.Dep src in
     let flags =
-      SC.expand_and_eval_set ~dir js_of_ocaml.Jbuild.Js_of_ocaml.flags
+      SC.expand_and_eval_set sctx ~scope ~dir js_of_ocaml.Jbuild.Js_of_ocaml.flags
         ~standard:(standard ())
     in
     [ flags

--- a/src/js_of_ocaml_rules.mli
+++ b/src/js_of_ocaml_rules.mli
@@ -14,10 +14,10 @@ val build_exe
   -> dir:Path.t
   -> js_of_ocaml:Js_of_ocaml.t
   -> src:Path.t
-  -> (Lib.t list * Path.t list, Action.t) Build.t list
+  -> ((Lib.t list * Path.t list) * string list, Action.t) Build.t list
 
 val setup_separate_compilation_rules
   :  Super_context.t
   -> (unit, Action.t) Build.t list
 
-
+val standard : unit -> string list

--- a/src/js_of_ocaml_rules.mli
+++ b/src/js_of_ocaml_rules.mli
@@ -4,6 +4,7 @@ open Jbuild
 
 val build_cm
   :  Super_context.t
+  -> scope:Scope.t
   -> dir:Path.t
   -> js_of_ocaml:Js_of_ocaml.t
   -> src:Path.t

--- a/src/merlin.mli
+++ b/src/merlin.mli
@@ -2,7 +2,7 @@
 
 type t =
   { requires   : (unit, Lib.t list) Build.t
-  ; flags      : string list
+  ; flags      : (unit, string list) Build.t
   ; preprocess : Jbuild.Preprocess.t
   ; libname    : string option
   }

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -79,7 +79,7 @@ let build_cm sctx ?sandbox ~dynlink ~flags ~cm_kind ~(dep_graph:Ocamldep.dep_gra
            ; A "-c"; Ml_kind.flag ml_kind; Dep src
            ])))
 
-let build_module sctx ?sandbox ~dynlink ~js_of_ocaml ~flags m ~dir ~dep_graph
+let build_module sctx ?sandbox ~dynlink ~js_of_ocaml ~flags m ~scope ~dir ~dep_graph
       ~modules ~requires ~alias_module =
   List.iter Cm_kind.all ~f:(fun cm_kind ->
     let requires = Cm_kind.Dict.get requires cm_kind in
@@ -87,9 +87,9 @@ let build_module sctx ?sandbox ~dynlink ~js_of_ocaml ~flags m ~dir ~dep_graph
       ~requires ~alias_module);
   (* Build *.cmo.js *)
   let src = Module.cm_file m ~dir Cm_kind.Cmo in
-  SC.add_rules sctx (Js_of_ocaml_rules.build_cm sctx ~dir ~js_of_ocaml ~src)
+  SC.add_rules sctx (Js_of_ocaml_rules.build_cm sctx ~scope ~dir ~js_of_ocaml ~src)
 
-let build_modules sctx ~dynlink ~js_of_ocaml ~flags ~dir ~dep_graph ~modules ~requires
+let build_modules sctx ~dynlink ~js_of_ocaml ~flags ~scope ~dir ~dep_graph ~modules ~requires
       ~alias_module =
   let cmi_requires =
     Build.memoize "cmi library dependencies"
@@ -114,5 +114,5 @@ let build_modules sctx ~dynlink ~js_of_ocaml ~flags ~dir ~dep_graph ~modules ~re
      | None -> modules
      | Some (m : Module.t) -> String_map.remove m.name modules)
     ~f:(fun ~key:_ ~data:m ->
-      build_module sctx m ~dynlink ~js_of_ocaml ~flags ~dir ~dep_graph ~modules ~requires
+      build_module sctx m ~dynlink ~js_of_ocaml ~flags ~scope ~dir ~dep_graph ~modules ~requires
         ~alias_module)

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -61,12 +61,13 @@ let build_cm sctx ?sandbox ~dynlink ~flags ~cm_kind ~(dep_graph:Ocamldep.dep_gra
       SC.add_rule sctx ?sandbox
         (Build.paths extra_deps >>>
          other_cm_files >>>
-         requires >>>
+         requires &&&
+         Ocaml_flags.get_for_cm flags ~cm_kind >>>
          Build.run ~context:ctx (Dep compiler)
            ~extra_targets
-           [ Ocaml_flags.get_for_cm flags ~cm_kind
+           [ Dyn (fun (_, ocaml_flags) -> As ocaml_flags)
            ; cmt_args
-           ; Dyn Lib.include_flags
+           ; Dyn (fun (libs, _) -> Lib.include_flags libs)
            ; As extra_args
            ; if dynlink || cm_kind <> Cmx then As [] else A "-nodynlink"
            ; A "-no-alias-deps"

--- a/src/module_compilation.mli
+++ b/src/module_compilation.mli
@@ -13,6 +13,7 @@ val build_module
   -> js_of_ocaml:Jbuild.Js_of_ocaml.t
   -> flags:Ocaml_flags.t
   -> Module.t
+  -> scope:Jbuild.Scope.t
   -> dir:Path.t
   -> dep_graph:Ocamldep.dep_graph
   -> modules:Module.t String_map.t
@@ -26,6 +27,7 @@ val build_modules
   -> dynlink:bool
   -> js_of_ocaml:Jbuild.Js_of_ocaml.t
   -> flags:Ocaml_flags.t
+  -> scope:Jbuild.Scope.t
   -> dir:Path.t
   -> dep_graph:Ocamldep.dep_graph
   -> modules:Module.t String_map.t

--- a/src/ocaml_flags.ml
+++ b/src/ocaml_flags.ml
@@ -37,8 +37,8 @@ type t =
   ; specific   : (unit, string list) Build.t Mode.Dict.t
   }
 
-let make { Jbuild.Buildable. flags; ocamlc_flags; ocamlopt_flags; _ } ~dir =
-  let eval = Super_context.expand_and_eval_set ~dir in
+let make { Jbuild.Buildable. flags; ocamlc_flags; ocamlopt_flags; _ } ctx ~scope ~dir =
+  let eval = Super_context.expand_and_eval_set ctx ~scope ~dir in
   { common   = Build.memoize "common flags" (eval flags ~standard:(default_flags ()))
   ; specific =
       { byte   = Build.memoize "ocamlc flags" (eval ocamlc_flags   ~standard:(default_ocamlc_flags ()))

--- a/src/ocaml_flags.ml
+++ b/src/ocaml_flags.ml
@@ -1,4 +1,5 @@
 open Import
+open Build.O
 
 let default_ocamlc_flags   = Utils.g
 let default_ocamlopt_flags = Utils.g
@@ -32,33 +33,38 @@ let default_flags () =
     [ "-w"; !Clflags.warnings ]
 
 type t =
-  { common   : string list
-  ; specific : string list Mode.Dict.t
+  { common     : (unit, string list) Build.t
+  ; specific   : (unit, string list) Build.t Mode.Dict.t
   }
 
-let make { Jbuild.Buildable. flags; ocamlc_flags; ocamlopt_flags; _ } =
-  let eval = Ordered_set_lang.eval_with_standard in
-  { common   = eval flags ~standard:(default_flags ())
+let make { Jbuild.Buildable. flags; ocamlc_flags; ocamlopt_flags; _ } ~dir =
+  let eval = Super_context.expand_and_eval_set ~dir in
+  { common   = Build.memoize "common flags" (eval flags ~standard:(default_flags ()))
   ; specific =
-      { byte   = eval ocamlc_flags   ~standard:(default_ocamlc_flags ())
-      ; native = eval ocamlopt_flags ~standard:(default_ocamlopt_flags ())
+      { byte   = Build.memoize "ocamlc flags" (eval ocamlc_flags   ~standard:(default_ocamlc_flags ()))
+      ; native = Build.memoize "ocamlopt flags" (eval ocamlopt_flags ~standard:(default_ocamlopt_flags ()))
       }
   }
 
-let get t mode = Arg_spec.As (t.common @ Mode.Dict.get t.specific mode)
+let get t mode =
+  t.common
+  &&&
+  (Mode.Dict.get t.specific mode)
+  >>^ fun (common, specific) ->
+  common @ specific
 
 let get_for_cm t ~cm_kind = get t (Mode.of_cm_kind cm_kind)
 
 let default () =
-  { common = default_flags ()
+  { common = Build.return (default_flags ())
   ; specific =
-      { byte   = default_ocamlc_flags   ()
-      ; native = default_ocamlopt_flags ()
+      { byte   = Build.return (default_ocamlc_flags   ())
+      ; native = Build.return (default_ocamlopt_flags ())
       }
   }
 
-let append_common t flags = {t with common = t.common @ flags}
+let append_common t flags = {t with common = t.common >>^ fun l -> l @ flags}
 
-let prepend_common flags t = {t with common = flags @ t.common}
+let prepend_common flags t = {t with common = t.common >>^ fun l -> flags @ l}
 
 let common t = t.common

--- a/src/ocaml_flags.ml
+++ b/src/ocaml_flags.ml
@@ -56,3 +56,9 @@ let default () =
       ; native = default_ocamlopt_flags ()
       }
   }
+
+let append_common t flags = {t with common = t.common @ flags}
+
+let prepend_common flags t = {t with common = flags @ t.common}
+
+let common t = t.common

--- a/src/ocaml_flags.mli
+++ b/src/ocaml_flags.mli
@@ -2,14 +2,14 @@
 
 type t
 
-val make : Jbuild.Buildable.t -> t
+val make : Jbuild.Buildable.t -> dir:Path.t -> t
 
 val default : unit -> t
 
-val get : t -> Mode.t -> _ Arg_spec.t
-val get_for_cm : t -> cm_kind:Cm_kind.t -> _ Arg_spec.t
+val get : t -> Mode.t -> (unit, string list) Build.t
+val get_for_cm : t -> cm_kind:Cm_kind.t -> (unit, string list) Build.t
 
 val append_common : t -> string list -> t
 val prepend_common : string list -> t -> t
 
-val common : t -> string list
+val common : t -> (unit, string list) Build.t

--- a/src/ocaml_flags.mli
+++ b/src/ocaml_flags.mli
@@ -2,7 +2,7 @@
 
 type t
 
-val make : Jbuild.Buildable.t -> dir:Path.t -> t
+val make : Jbuild.Buildable.t -> Super_context.t -> scope:Jbuild.Scope.t -> dir:Path.t -> t
 
 val default : unit -> t
 

--- a/src/ocaml_flags.mli
+++ b/src/ocaml_flags.mli
@@ -1,9 +1,6 @@
 (** OCaml flags *)
 
-type t =
-  { common   : string list
-  ; specific : string list Mode.Dict.t
-  }
+type t
 
 val make : Jbuild.Buildable.t -> t
 
@@ -12,3 +9,7 @@ val default : unit -> t
 val get : t -> Mode.t -> _ Arg_spec.t
 val get_for_cm : t -> cm_kind:Cm_kind.t -> _ Arg_spec.t
 
+val append_common : t -> string list -> t
+val prepend_common : string list -> t -> t
+
+val common : t -> string list

--- a/src/ordered_set_lang.ml
+++ b/src/ordered_set_lang.ml
@@ -1,40 +1,58 @@
 open! Import
 
-type t = Sexp.Ast.t
+module Ast = struct
+  [@@@warning "-37"]
+  type expanded = Expanded
+  type unexpanded = Unexpanded
+  type ('a, _) t =
+    | Element : 'a -> ('a, _) t
+    | Special : Loc.t * string -> ('a, _) t
+    | Union : ('a, 'b) t list -> ('a, 'b) t
+    | Diff : ('a, 'b) t * ('a, 'b) t -> ('a, 'b) t
+    | Include : 'a -> ('a, unexpanded) t
+end
 
-let t t = t
+type t = (string, Ast.expanded) Ast.t
 
-let eval t ~special_values =
+let t t : t =
   let rec of_sexp : Sexp.Ast.t -> _ = function
     | Atom (loc, "\\") -> Loc.fail loc "unexpected \\"
+    | Atom (_, "") -> Ast.Element ""
     | Atom (loc, s) ->
-      let len = String.length s in
-      if len > 0 && s.[0] = ':' then
-        let name = String.sub s ~pos:1 ~len:(len - 1) in
-        match List.assoc name special_values with
-        | l -> l
-        | exception Not_found -> Loc.fail loc "undefined symbol %s" s;
+      if s.[0] = ':' then
+        Special (loc, String.sub s ~pos:1 ~len:(String.length s - 1))
       else
-        [s]
+        Element s
     | List (_, sexps) -> of_sexps [] sexps
   and of_sexps acc = function
-    | Atom (_, "\\") :: sexps -> of_sexps_negative acc sexps
+    | Atom (_, "\\") :: sexps -> Diff (Union (List.rev acc), of_sexps [] sexps)
     | elt :: sexps ->
-      let elts = of_sexp elt in
-      of_sexps (List.rev_append elts acc) sexps
-    | [] -> List.rev acc
-  and of_sexps_negative acc = function
-    | Atom (_, "\\") :: sexps -> of_sexps_negative acc sexps
-    | elt :: sexps ->
-      let elts = of_sexp elt in
-      let acc = List.filter acc ~f:(fun acc_elt -> not (List.mem acc_elt ~set:elts)) in
-      of_sexps_negative acc sexps
-    | [] -> List.rev acc
+      of_sexps (of_sexp elt :: acc) sexps
+    | [] -> Union (List.rev acc)
   in
   of_sexp t
 
+let eval t ~special_values =
+  let rec of_ast (t : t) =
+    let open Ast in
+    match t with
+    | Element s -> [s]
+    | Special (loc, name) ->
+        begin
+          match List.assoc name special_values with
+          | l -> l
+          | exception Not_found -> Loc.fail loc "undefined symbol %s" name;
+        end
+    | Union elts -> List.flatten (List.map elts ~f:of_ast)
+    | Diff (left, right) ->
+        let left = of_ast left in
+        let right = of_ast right in
+        List.filter left ~f:(fun acc_elt -> not (List.mem acc_elt ~set:right))
+  in
+  of_ast t
+
 let is_standard : t -> bool = function
-  | Atom (_, ":standard") -> true
+  | Ast.Special (_, "standard") -> true
   | _ -> false
 
 let eval_with_standard t ~standard =
@@ -43,40 +61,65 @@ let eval_with_standard t ~standard =
   else
     eval t ~special_values:[("standard", standard)]
 
-let rec map (t : t) ~f =
+let rec map (t : t) ~f : t =
+  let open Ast in
   match t with
-  | Atom (loc, s) ->
-    let len = String.length s in
-    if len > 0 && s.[0] = ':' then
-      t
-    else
-      Atom (loc, f s)
-  | List (loc, l) -> List (loc, List.map l ~f:(map ~f))
+  | Element s -> Element (f s)
+  | Special _ -> t
+  | Union l -> Union (List.map l ~f:(map ~f))
+  | Diff (l, r) -> Diff (map l ~f, map r ~f)
 
-let standard : t = Atom (Loc.none, ":standard")
+let standard = Ast.Special (Loc.none, "standard")
 
-let append a b : t = List (Loc.none, [a; b])
+let append a b = Ast.Union [a; b]
 
 module Unexpanded = struct
-  type nonrec t = t
-  let t t = t
+  type t = (string, Ast.unexpanded) Ast.t
+  let parse_expanded = t
+  let t t' =
+    let rec map (t : (string, Ast.expanded) Ast.t) =
+      let open Ast in
+      match t with
+      | Element s -> Element s
+      | Special (l, s) -> Special (l, s)
+      | Union [Special (_, "include"); Element fn] ->
+          Include fn
+      | Union l ->
+          Union (List.map l ~f:map)
+      | Diff (l, r) ->
+          Diff (map l, map r)
+    in
+    t t' |> map
+
   let standard = standard
 
   let append = append
 
   let files t =
-    let rec loop acc : t -> _ = function
-      | Atom _ -> acc
-      | List (_, [Atom (_, ":include"); Atom (_, fn)]) -> String_set.add fn acc
-      | List (_, l) -> List.fold_left l ~init:acc ~f:loop
+    let rec loop acc (t : t) =
+      let open Ast in
+      match t with
+      | Element _
+      | Special _ -> acc
+      | Include fn ->
+          String_set.add fn acc
+      | Union l ->
+          List.fold_left l ~init:acc ~f:loop
+      | Diff (l, r) ->
+          loop (loop acc l) r
     in
     loop String_set.empty t
 
-  let rec expand (t : t) ~files_contents =
+  let rec expand (t : t) ~files_contents : (string, Ast.expanded) Ast.t =
+    let open Ast in
     match t with
-    | Atom _ -> t
-    | List (_, [Atom (_, ":include"); Atom (_, fn)]) ->
-      String_map.find_exn fn files_contents ~string_of_key:(sprintf "%S")
-        ~desc:(fun _ -> "<filename to s-expression>")
-    | List (loc, l) -> List (loc, List.map l ~f:(expand ~files_contents))
+    | Element s -> Element s
+    | Special (l, s) -> Special (l, s)
+    | Include fn ->
+        parse_expanded (String_map.find_exn fn files_contents ~string_of_key:(sprintf "%S")
+          ~desc:(fun _ -> "<filename to s-expression>"))
+    | Union l ->
+        Union (List.map l ~f:(expand ~files_contents))
+    | Diff (l, r) ->
+        Diff (expand l ~files_contents, expand r ~files_contents)
 end

--- a/src/ordered_set_lang.mli
+++ b/src/ordered_set_lang.mli
@@ -27,6 +27,6 @@ module Unexpanded : sig
 
   (** Expand [t] using with the given file contents. [file_contents] is a map from
       filenames to their parsed contents. Every [(:include fn)] in [t] is replaced by
-      [Map.find files_contents fn]. *)
-  val expand : t -> files_contents:Sexp.Ast.t String_map.t -> expanded
+      [Map.find files_contents fn]. Every element is converted to a string using [f]. *)
+  val expand : t -> files_contents:Sexp.Ast.t String_map.t -> f:(Sexp.Ast.t -> string) -> expanded
 end with type expanded := t

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -168,7 +168,9 @@ module PP : sig
 end
 
 val expand_and_eval_set
-  :  dir:Path.t
+  :  t
+  -> scope:Scope.t
+  -> dir:Path.t
   -> Ordered_set_lang.Unexpanded.t
   -> standard:string list
   -> (unit, string list) Build.t


### PR DESCRIPTION
As per the title - with thanks and due credit to @diml for patient pointers through the internals of jbuilder!

Longer term the aim is to also extend `${read ...}` forms from the action DSL, but this is a necessary first step, and possibly the `${read ...}` change should be for 1.1 anyway?

It would be very good to have this in 1.0 - I shall be experimenting with it later to convert some of my OCaml Syntax jbuild files back to s-expression only.