### PR TITLE
Fix some warning 50 for 4.02.3

### DIFF
--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -79,7 +79,7 @@ module Libs : sig
     :  t
     -> dir:Path.t
     -> dep_kind:Build.lib_dep_kind
-    -> item:string (** Library name or first exe name *)
+    -> item:string (* Library name or first exe name *)
     -> libraries:Lib_deps.t
     -> preprocess:Preprocess_map.t
     -> virtual_deps:string list
@@ -90,7 +90,7 @@ module Libs : sig
     :  t
     -> dir:Path.t
     -> dep_kind:Build.lib_dep_kind
-    -> item:string (** Library name or first exe name *)
+    -> item:string (* Library name or first exe name *)
     -> libraries:Lib_deps.t
     -> ppx_runtime_libraries:string list
     -> unit

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -22,7 +22,7 @@ val describe_target : Path.t -> string
     assume that the program was looked up in the tree as well. *)
 val program_not_found
   :  ?context:string
-  -> ?in_the_tree:bool (** default: false *)
+  -> ?in_the_tree:bool (* default: false *)
   -> ?hint:string
   -> string
   -> _


### PR DESCRIPTION
Warning 50: unattached documentation comment (ignored)

But I don't understand why travis does not catch that.