### PR TITLE
Adding dependencies ordering constraint during linking

### DIFF
--- a/doc/jbuild.rst
+++ b/doc/jbuild.rst
@@ -226,6 +226,15 @@ binary at the same place as where ``ocamlc`` was found, or when there is a
 - ``(libraries (<library-dependencies>))`` specifies the library dependencies.
   See the section about `Library dependencies`_ for more details
 
+- ``(dependencies_ordering ((<librarie> <librarie>) ...)`` each pair
+  specifies that the first library must be linked before the second
+  one. Both libraries must already appear directly (not in a select)
+  in the ``libraries`` field. It can be used for fixing missing
+  dependencies in external libraries. More interrestingly it could be
+  used to make sure that the initialization of a library will be
+  executed before the initialisation of another one because of some
+  side effects.
+
 - ``(modules <modules>)`` specifies which modules in the current directory
   Jbuilder should consider when building this executable. Modules not listed
   here will be ignored and cannot be used inside the executable described by

--- a/src/findlib.ml
+++ b/src/findlib.ml
@@ -507,11 +507,13 @@ let check_deps_consistency ~required_by ~local_public_libs pkg requires =
                ; defined_locally_in  = path
                }))
 
+let requires ~required_by ~local_public_libs pkg =
+  check_deps_consistency ~required_by ~local_public_libs pkg pkg.requires;
+  pkg.requires
+
 let closure ~required_by ~local_public_libs pkgs =
   remove_dups_preserve_order
-    (List.concat_map pkgs ~f:(fun pkg ->
-       check_deps_consistency ~required_by ~local_public_libs pkg pkg.requires;
-       pkg.requires)
+    (List.concat_map pkgs ~f:(requires ~required_by ~local_public_libs)
      @ pkgs)
 
 let closed_ppx_runtime_deps_of ~required_by ~local_public_libs pkgs =

--- a/src/findlib.mli
+++ b/src/findlib.mli
@@ -76,6 +76,11 @@ val closed_ppx_runtime_deps_of
   -> local_public_libs:Path.t String_map.t
   -> package list
   -> package list
+val requires
+  :  required_by:Path.t
+  -> local_public_libs:Path.t String_map.t
+  -> package
+  -> package list
 
 val root_packages : t -> string list
 val all_packages  : t -> package list

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -258,6 +258,7 @@ module Gen(P : Params) = struct
         ~libraries:lib.buildable.libraries
         ~preprocess:lib.buildable.preprocess
         ~virtual_deps:lib.virtual_deps
+        ~deps_ordering:[]
     in
 
     SC.Libs.setup_runtime_deps sctx ~dir ~dep_kind ~item:lib.name
@@ -481,6 +482,7 @@ module Gen(P : Params) = struct
         ~libraries:exes.buildable.libraries
         ~preprocess:exes.buildable.preprocess
         ~virtual_deps:[]
+        ~deps_ordering:exes.deps_ordering
     in
 
     SC.Libs.add_select_rules sctx ~dir exes.buildable.libraries;

--- a/src/import.ml
+++ b/src/import.ml
@@ -76,6 +76,10 @@ module List = struct
       max acc (String.length (f x)))
 
   let longest l = longest_map l ~f:(fun x -> x)
+
+  let hd_opt = function
+    | [] -> None
+    | a::_ -> Some a
 end
 
 module Hashtbl = struct

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -173,6 +173,7 @@ module Executables : sig
     ; link_flags       : string list
     ; modes            : Mode.Dict.Set.t
     ; buildable        : Buildable.t
+    ; deps_ordering    : (string * string) list
     }
 end
 

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -21,6 +21,10 @@ end
 
 include T
 module Set = Set.Make(T)
+module Map = Map.Make(T)
+
+let mk_internal i = Internal i
+let mk_external i = External i
 
 let dir = function
   | Internal (dir, _) -> dir

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -1,7 +1,18 @@
 open Import
 
 module Internal = struct
-  type t = Path.t * Jbuild.Library.t
+  module T = struct
+    type t = Path.t * Jbuild.Library.t
+    let best_name ((_, lib):t) =
+      match lib.public with
+      | Some p -> p.name
+      | None -> lib.name
+
+    let compare a b = String.compare (best_name a) (best_name b)
+  end
+  include T
+  module Set = Set.Make(T)
+  module Map = Map.Make(T)
 end
 
 module T = struct
@@ -11,10 +22,7 @@ module T = struct
 
   let best_name = function
     | External pkg -> pkg.name
-    | Internal (_, lib) ->
-      match lib.public with
-      | Some p -> p.name
-      | None -> lib.name
+    | Internal lib -> Internal.best_name lib
 
   let compare a b = String.compare (best_name a) (best_name b)
 end

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -8,7 +8,13 @@ type t =
   | Internal of Internal.t
   | External of Findlib.package
 
+val compare: t -> t -> int
+
 module Set : Set.S with type elt := t
+module Map : Map.S with type key := t
+
+val mk_internal: Internal.t -> t
+val mk_external: Findlib.package -> t
 
 (*val deps : t -> string list*)
 

--- a/src/lib_db.mli
+++ b/src/lib_db.mli
@@ -15,6 +15,7 @@ val create
 
 val find     : t -> from:Path.t -> string -> Lib.t option
 val find_exn : t -> from:Path.t -> string -> Lib.t
+val find_fail : t -> from:Path.t -> string -> (Lib.t,fail) result
 
 val internal_libs_without_non_installable_optional_ones : t -> Lib.Internal.t list
 

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -83,6 +83,7 @@ module Libs : sig
     -> libraries:Lib_deps.t
     -> preprocess:Preprocess_map.t
     -> virtual_deps:string list
+    -> deps_ordering: (string * string) list
     -> (unit, Lib.t list) Build.t * (unit, Lib.t list) Build.t
 
   (** Setup the rules for ppx runtime dependencies *)

--- a/src/top_closure.ml
+++ b/src/top_closure.ml
@@ -37,4 +37,19 @@ module Make(Key : Set.OrderedType)(Elt : Elt with type key := Key.t) = struct
     match iter_elts elements ~temporarily_marked:Set.empty with
     | Ok () -> Ok (List.rev !res)
     | Error elts -> Error elts
+
+
+  let accessibles graph elements =
+    let rec aux (visited,acc) e =
+      let key = Elt.key e in
+      if Set.mem key visited then (visited,acc)
+      else
+        let visited = Set.add key visited in
+        let acc = e::acc in
+        let l = Elt.deps e graph in
+        List.fold_left ~f:aux ~init:(visited,acc) l
+    in
+    let _,acc = List.fold_left ~f:aux ~init:(Set.empty,[]) elements in
+    acc
+
 end

--- a/src/top_closure.mli
+++ b/src/top_closure.mli
@@ -11,4 +11,6 @@ end
 module Make(Key : Set.OrderedType)(Elt : Elt with type key := Key.t) : sig
   (** Returns [Error cycle] in case the graph is not a DAG *)
   val top_closure : Elt.graph -> Elt.t list -> (Elt.t list, Elt.t list) result
+
+  val accessibles : Elt.graph -> Elt.t list -> Elt.t list
 end

--- a/test/jbuild
+++ b/test/jbuild
@@ -104,3 +104,15 @@
   (deps ((alias sleep5)
          (alias sleep4-and-fail)
          (alias sleep1-and-fail)))))
+
+(alias
+ ((name runtest)
+  (deps ((files_recursively_in workspaces/dependencies_ordering)))
+  (action
+   (chdir workspaces/dependencies_ordering
+    (progn
+      (run ${exe:run.exe} -log log.build --
+     ${bin:jbuilder} build -j1 @install --root . --debug-dependency-path)
+     (run ${exe:run.exe} -log log.exec-tool -- ${bin:jbuilder} exec --root . tool -- cmdline)
+     (run ${exe:run.exe} -log log.exec-tool-gui -- ${bin:jbuilder} exec  --root . tool-gui -- gui))
+  ))))

--- a/test/workspaces/dependencies_ordering/config.ml
+++ b/test/workspaces/dependencies_ordering/config.ml
@@ -1,0 +1,3 @@
+type mode = Cmdline | Gui
+
+let mode = ref Cmdline

--- a/test/workspaces/dependencies_ordering/gui.ml
+++ b/test/workspaces/dependencies_ordering/gui.ml
@@ -1,0 +1,1 @@
+let () = Config.mode := Config.Gui

--- a/test/workspaces/dependencies_ordering/jbuild
+++ b/test/workspaces/dependencies_ordering/jbuild
@@ -1,0 +1,55 @@
+(jbuild_version 1)
+
+(ocamllex (lexer1 lexer2))
+
+(library
+ ((name tool_config)
+  (public_name tool.config)
+  (modules (config))))
+
+(library (
+  (name tool_gui)
+  (public_name tool.gui)
+  (flags (-open Tool_config))
+  (modules (gui))
+  (libraries (tool.config))
+))
+
+(library (
+ (name tool_boot)
+ (public_name tool.boot)
+ (flags (-open Tool_config))
+ (modules (boot))
+ (libraries (tool.config))
+))
+
+(rule (
+  (targets (empty_file.ml))
+  (action (with-stdout-to ${@} (echo "")))
+))
+
+(rule (
+  (targets (empty_file_gui.ml))
+  (deps (empty_file.ml))
+  (action (copy# ${<} ${@}))
+))
+
+
+(executable (
+  (name empty_file)
+  (public_name tool)
+  (modules (empty_file))
+  (flags (-linkall))
+  (libraries (tool.boot))
+  (package tool)
+))
+
+(executable (
+  (name empty_file_gui)
+  (public_name tool-gui)
+  (modules (empty_file_gui))
+  (flags (-linkall))
+  (libraries (tool.gui tool.boot))
+  (dependencies_ordering ((tool.gui tool.boot)))
+  (package tool)
+))

--- a/test/workspaces/dependencies_ordering/tool.ml
+++ b/test/workspaces/dependencies_ordering/tool.ml
@@ -1,0 +1,4 @@
+let () =
+  match !Config.mode with
+  | Config.Cmdline -> Printf.printf "I'm a cmdline tool I must print log in stdout"
+  | Config.Gui -> Printf.printf "I'm a gui tool I must print log in the interface"


### PR DESCRIPTION
Add the field `dependencies_ordering` to executable stanza.

``(dependencies_ordering ((<librarie> <librarie>) ...)`` each pair specifies that the first library must be  linked before the second one. Both libraries must already appear directly (not in a select) in the ``libraries`` field. It can be used for fixing missing dependencies in external libraries. More interrestingly it could be used to make sure that the initialization of a library will be executed before the initialisation of another one because of some side effects.