### PR TITLE
Fix jbuilder support without opam

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -248,17 +248,27 @@ to be able to use ``jbuilder install``.
 Destination
 -----------
 
-The place where the build artifacts are copied, usually referred as
+The place where the build artifacts (except ocaml libraries) are copied, usually referred as
 **prefix**, is determined as follow for a given build context:
 
 #. if an explicit ``--prefix <path>`` argument is passed, use this path
 #. if ``opam`` is present in the ``PATH``, use the output of ``opam config var
    prefix``
-#. otherwise, take the directory where ``ocamlc`` was found, and append
-   ``../lib`` to it. For instance if ``ocamlc`` is found in ``/usr/bin``, use
-   ``/usr``
+#. otherwise, take the parent of the directory where ``ocamlc`` was found.
 
-Note that ``--prefix`` is only supported if a single build context is in
+The ocaml libraries build artifacts are copied, referred as
+**libdir**, is determined as follow for a given build context:
+
+#. if an explicit ``--libdir <path>`` argument is passed, use this path
+#. if ``ocamlfind`` is present in the ``PATH``, use the output of
+   ``ocamlfind printconf destdir``
+#. if ``opam`` is present in the ``PATH``, use the output of ``opam config var
+   lib``
+#. otherwise, take the directory of the ocaml standard library
+
+
+
+Note that ``--prefix`` and ``--libdir`` are only supported if a single build context is in
 use.
 
 Workspace configuration

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -248,7 +248,7 @@ to be able to use ``jbuilder install``.
 Destination
 -----------
 
-The place where the build artifacts (except ocaml libraries) are copied, usually referred as
+The place where the build artifacts (except library files) are copied, usually referred as
 **prefix**, is determined as follow for a given build context:
 
 #. if an explicit ``--prefix <path>`` argument is passed, use this path
@@ -256,10 +256,11 @@ The place where the build artifacts (except ocaml libraries) are copied, usually
    prefix``
 #. otherwise, take the parent of the directory where ``ocamlc`` was found.
 
-The ocaml libraries build artifacts are copied, referred as
+The place where the library files are copied, referred as
 **libdir**, is determined as follow for a given build context:
 
 #. if an explicit ``--libdir <path>`` argument is passed, use this path
+#. if an explicit ``--prefix <path>`` argument is passed, use ``<path>/lib``
 #. if ``ocamlfind`` is present in the ``PATH``, use the output of
    ``ocamlfind printconf destdir``
 #. if ``opam`` is present in the ``PATH``, use the output of ``opam config var

--- a/src/context.ml
+++ b/src/context.ml
@@ -126,11 +126,13 @@ let opam_config_var ~env ~cache var =
     match Bin.opam with
     | None -> return None
     | Some fn ->
-      Future.run_capture Strict (Path.to_string fn) ~env ["config"; "var"; var]
-      >>| fun s ->
-      let s = String.trim s in
-      Hashtbl.add cache ~key:var ~data:s;
-      Some s
+      Future.run_capture (Accept All) (Path.to_string fn) ~env ["config"; "var"; var]
+      >>| function
+      | Ok s ->
+        let s = String.trim s in
+        Hashtbl.add cache ~key:var ~data:s;
+        Some s
+      | Error _ -> None
 
 let get_env env var =
   let rec loop i =

--- a/src/context.ml
+++ b/src/context.ml
@@ -198,31 +198,8 @@ let create ~(kind : Kind.t) ~path ~base_env ~env_extra ~name ~merlin ~use_findli
     Path.of_string (sprintf "_build/%s" name)
   in
   let ocamlc_config_cmd = sprintf "%s -config" (Path.to_string ocamlc) in
-  let findlib_path =
-    if use_findlib then
-      (* If ocamlfind is present, it has precedence over everything else. *)
-      match which "ocamlfind" with
-      | Some fn ->
-        (Future.run_capture_lines ~env Strict
-           (Path.to_string fn) ["printconf"; "path"]
-         >>| List.map ~f:Path.absolute)
-      | None ->
-        (* If there no ocamlfind in the PATH, check if we have opam and assume a standard
-           opam setup *)
-        opam_config_var ~env ~cache:opam_var_cache "lib"
-        >>| function
-        | Some s -> [Path.absolute s]
-        | None ->
-          (* If neither opam neither ocamlfind are present, assume that libraries are in
-             [dir ^ "/../lib"] *)
-          [Path.relative (Path.parent dir) "lib"]
-    else
-      return []
-  in
-  both
-    findlib_path
-    (Future.run_capture_lines ~env Strict (Path.to_string ocamlc) ["-config"])
-  >>= fun (findlib_path, ocamlc_config) ->
+  Future.run_capture_lines ~env Strict (Path.to_string ocamlc) ["-config"]
+  >>= fun ocamlc_config ->
   let ocamlc_config =
     List.map ocamlc_config ~f:(fun line ->
       match String.index line ':' with
@@ -301,6 +278,28 @@ let create ~(kind : Kind.t) ~path ~base_env ~env_extra ~name ~merlin ~use_findli
       let _, ocamlopt_cflags = split_prog (get "native_c_compiler") in
       (c_compiler, ocamlc_cflags, ocamlopt_cflags)
   in
+  let findlib_path =
+    if use_findlib then
+      (* If ocamlfind is present, it has precedence over everything else. *)
+      match which "ocamlfind" with
+      | Some fn ->
+        (Future.run_capture_lines ~env Strict
+           (Path.to_string fn) ["printconf"; "path"]
+         >>| List.map ~f:Path.absolute)
+      | None ->
+        (* If there no ocamlfind in the PATH, check if we have opam and assume a standard
+           opam setup *)
+        opam_config_var ~env ~cache:opam_var_cache "lib"
+        >>| function
+        | Some s -> [Path.absolute s]
+        | None ->
+          (* If neither opam neither ocamlfind are present, assume that libraries are in
+             the stdlib directory *)
+          [stdlib_dir]
+    else
+      return []
+  in
+  findlib_path >>= fun findlib_path ->
   return
     { name
     ; kind
@@ -425,6 +424,23 @@ let install_prefix t =
   opam_config_var t "prefix" >>| function
   | Some x -> Path.absolute x
   | None   -> Path.parent t.ocaml_bin
+
+let install_ocaml_libdir t =
+  (* If ocamlfind is present, it has precedence over everything else. *)
+  match which t "ocamlfind" with
+  | Some fn ->
+    (Future.run_capture_line ~env:t.env Strict
+       (Path.to_string fn) ["printconf"; "destdir"]
+     >>| Path.absolute)
+  | None ->
+    (* If there no ocamlfind in the PATH, check if we have opam and assume a standard
+       opam setup *)
+    opam_config_var t "lib"
+    >>| function
+    | Some s -> Path.absolute s
+    | None ->
+      (* If neither opam neither ocamlfind are present use stdlib dir *)
+      t.stdlib_dir
 
 
 (* CR-someday jdimino: maybe we should just do this for [t.env] directly? *)

--- a/src/context.mli
+++ b/src/context.mli
@@ -144,6 +144,7 @@ val extend_env : vars:string Env_var_map.t -> env:string array -> string array
 val opam_config_var : t -> string -> string option Future.t
 
 val install_prefix : t -> Path.t Future.t
+val install_ocaml_libdir : t -> Path.t Future.t
 
 val env_for_exec : t -> string array
 


### PR DESCRIPTION
Doesn't change that `opam-installer` must be available.

Should fix #174 by:
 - considering that an opam failing is an opam not present
 - use the option `libdir` of `opam-installer` for the case where libraries should not be installed in `$PREFIX/lib`

`libdir` is:
 1.  the argument given on the command line of `jbuilder install`
 1.  `ocamlfind printconf destdir`
 1. `opam config lib`
 1.  OCaml standard library path.