### PR TITLE
Use full path for non OCaml findlib archives

### DIFF
--- a/src/findlib.ml
+++ b/src/findlib.ml
@@ -236,9 +236,17 @@ let parse_package t ~name ~parent_dir ~vars ~required_by =
     else
       Path.absolute pkg_dir
   in
+  let expand_paths =
+    let dir = Path.to_string dir in
+    fun archive ->
+      if String.is_prefix (Filename.extension archive) ~prefix:".cm" then
+        archive
+      else
+        Filename.concat dir archive
+  in
   let archives var preds =
     Mode.Dict.of_func (fun ~mode ->
-      Vars.get_words vars var (Mode.findlib_predicate mode :: preds))
+      Vars.get_words vars var (Mode.findlib_predicate mode :: preds) |> List.map ~f:expand_paths)
   in
   let jsoo_runtime = Vars.get_words vars "jsoo_runtime" [] in
   let preds = ["ppx_driver"; "mt"; "mt_posix"] in


### PR DESCRIPTION
The archive member of a META usually contains OCaml files (.cma, .cmxa, .cmxs, etc.) but can also include C object files. These aren't found by the linker unless they are referenced with their full path. ocamlfind
does this for everything, so the issue would never be seen when using it as a frontend.

This should fix #177 - @UnixJunkie, would you be able to test?

@diml - findlib prefixes all the archives, but I've rigged this only to do it for non-OCaml ones. What do you think?