### PR TITLE
CI changes

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -xue
+
+PATH=~/ocaml/bin:$PATH; export PATH
+
+TARGET="$1"; shift
+
+case "$TARGET" in
+  prepare)
+    if [ ! -e ~/ocaml/cached-version -o "$(cat ~/ocaml/cached-version)" != "$OCAML_VERSION.$OCAML_RELEASE" ] ; then
+      rm -rf ~/ocaml
+      mkdir -p ~/ocaml/src
+      cd ~/ocaml/src
+      wget http://caml.inria.fr/pub/distrib/ocaml-$OCAML_VERSION/ocaml-$OCAML_VERSION.$OCAML_RELEASE.tar.gz
+      tar -xzf ocaml-$OCAML_VERSION.$OCAML_RELEASE.tar.gz
+      cd ocaml-$OCAML_VERSION.$OCAML_RELEASE
+      ./configure -prefix ~/ocaml
+      make world.opt
+      make install
+      cd ..
+      rm -rf src
+      echo "$OCAML_VERSION.$OCAML_RELEASE" > ~/ocaml/cached-version
+    fi
+  ;;
+  build)
+    ocaml bootstrap.ml
+    ./boot.exe --subst
+    ./boot.exe --dev
+  ;;
+  *)
+    echo "bad command $TARGET">&2; exit 1
+esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,20 @@
 language: c
-sudo: required
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
-script: bash -ex .travis-opam.sh
+sudo: false
+
+cache:
+  directories:
+  - $HOME/ocaml
+
+install: bash -ex .travis-ci.sh prepare
+script: bash -ex .travis-ci.sh build
 env:
   global:
   - PACKAGE=jbuilder
   matrix:
-  - OCAML_VERSION=4.02
-  - OCAML_VERSION=4.03
-  - OCAML_VERSION=4.04
+  - OCAML_VERSION=4.02 OCAML_RELEASE=3
+  - OCAML_VERSION=4.03 OCAML_RELEASE=0
+  - OCAML_VERSION=4.04 OCAML_RELEASE=2
+  - OCAML_VERSION=4.05 OCAML_RELEASE=0+rc1
 os:
   - linux
   - osx

--- a/src/context.ml
+++ b/src/context.ml
@@ -22,7 +22,7 @@ module Env_var = struct
   type t = string
   let compare a b =
     if Sys.win32 then
-      String.compare (String.lowercase a) (String.lowercase b)
+      String.compare (String.lowercase_ascii a) (String.lowercase_ascii b)
     else
       String.compare a b
 end

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -39,7 +39,7 @@ let compile_module sctx (m : Module.t) ~odoc ~dir ~includes ~dep_graph ~modules
 let to_html sctx (m : Module.t) odoc_file ~doc_dir ~odoc ~dir ~includes
       ~lib_public_name ~(lib : Library.t) =
   let context = SC.context sctx in
-  let html_dir = doc_dir ++ lib_public_name ++ String.capitalize m.obj_name in
+  let html_dir = doc_dir ++ lib_public_name ++ String.capitalize_ascii m.obj_name in
   let html_file = html_dir ++ "index.html" in
   SC.add_rule sctx
     (SC.Libs.static_file_deps (dir, lib) ~ext:odoc_ext
@@ -79,7 +79,7 @@ let lib_index sctx ~odoc ~dir ~(lib : Library.t) ~lib_public_name ~doc_dir ~modu
                The entry point for this library is module {!module:%s}."
               header
               lib_public_name
-              (String.capitalize lib.name)
+              (String.capitalize_ascii lib.name)
           else
             sprintf
               "%s\n\


### PR DESCRIPTION
A few changes to the Travis CI set-up:
 - Include OCaml 4.05 in the test matrix
 - Stop using opam, as it's not necessary, and build the compiler directly
 - As a result of that simplification, build using `--dev`, and as a result a commit of @bobot's from #179 which fixes a few deprecation warnings

@rgrinberg - please could you cast an eye over this? Then we can be testing 4.05 meaningfully before @diml gets back from vacation!
