### PR TITLE
utop subcommand

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -906,9 +906,8 @@ let utop =
   let doc = "Load library in utop" in
   let man = [ (* TODO *) ] in
   let go common dir =
-    (* we don't know what the targets are without setting up the rules first and
-       looking up where the utop exe's are located *)
-    set_common common ~targets:[];
+    let utop_target = dir |> Path.of_string |> Utop.target |> Path.to_string in
+    set_common common ~targets:[utop_target];
     (* We must wait for other exit hooks to finish before forking. This is
        necessary to make sure the trace file is dumped before we fork. *)
     let utop_path = ref None in
@@ -918,22 +917,13 @@ let utop =
     let log = Log.create () in
     Future.Scheduler.go ~log
       (Main.setup ~log common >>= fun setup ->
-       let utop_target =
-         let default_context =
-           setup.contexts
-           |> List.find ~f:(fun c ->
-             match c.Context.kind with
-             | Default -> true
-             | Opam _ -> false)
-           |> Option.value_exn in
-         Utop.target default_context (Path.of_string dir) in
-       let targets = resolve_targets ~log common setup [Path.to_string utop_target] in
+       let targets = resolve_targets ~log common setup [utop_target] in
        do_build setup targets >>| fun () ->
-       utop_path := Some utop_target) in
+       utop_path := Some (List.hd targets)) in
   let name_ = Arg.info [] ~docv:"PATH" in
   ( Term.(const go
           $ common
-          $ Arg.(required & pos 0 (some string) None name_))
+          $ Arg.(value & pos 0 dir "" name_))
   , Term.info "utop" ~doc ~man )
 
 let all =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -905,7 +905,7 @@ let subst =
 let utop =
   let doc = "Load library in utop" in
   let man = [ (* TODO *) ] in
-  let go common =
+  let go common dir =
     (* we don't know what the targets are without setting up the rules first and
        looking up where the utop exe's are located *)
     set_common common ~targets:[];
@@ -926,12 +926,15 @@ let utop =
              | Default -> true
              | Opam _ -> false)
            |> Option.value_exn in
-         Utop.target default_context in
+         Utop.target default_context (Path.of_string dir) in
        let targets = resolve_targets ~log common setup [Path.to_string utop_target] in
        do_build setup targets >>| fun () ->
        utop_path := Some utop_target) in
-  ( Term.(const go $ common)
-  , Term.info "utop" ~doc ~man)
+  let name_ = Arg.info [] ~docv:"PATH" in
+  ( Term.(const go
+          $ common
+          $ Arg.(required & pos 0 (some string) None name_))
+  , Term.info "utop" ~doc ~man )
 
 let all =
   [ installed_libraries

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -919,16 +919,13 @@ let utop =
              |> List.map ~f:(fun c -> c.Context.name)
              |> String.concat ~sep:",")
          | Some name, _ -> Main.find_context_exn setup ~name in
+       let setup = { setup with contexts = [context] } in
        let target =
          match resolve_targets ~log common setup [utop_target] with
          | [] -> die "no libraries defined in %s" dir
          | [target] -> target
-         | targets ->
-           match List.find targets ~f:(Path.is_descendant
-                                         ~of_:context.Context.build_dir) with
-           | Some s -> s
-           | None -> die "Couldn't find target for %s in context %s" dir
-                       context.Context.name in
+         | _::_::_ -> assert false
+       in
        do_build setup [target] >>| fun () ->
        (setup.build_system, context, Path.to_string target)
       ) |> Future.Scheduler.go ~log in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -906,7 +906,7 @@ let utop =
   let doc = "Load library in utop" in
   let man = [ (* TODO *) ] in
   let go common dir args =
-    let utop_target = dir |> Path.of_string |> Utop.target |> Path.to_string in
+    let utop_target = dir |> Path.of_string |> Utop.utop_exe |> Path.to_string in
     set_common common ~targets:[utop_target];
     (* We must wait for other exit hooks to finish before forking. This is
        necessary to make sure the trace file is dumped before we fork. *)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -795,6 +795,11 @@ let install_uninstall ~what =
 let install   = install_uninstall ~what:"install"
 let uninstall = install_uninstall ~what:"uninstall"
 
+let context_arg ~doc =
+  Arg.(value
+       & opt string "default"
+       & info ["context"] ~docv:"CONTEXT" ~doc)
+
 let exec =
   let doc =
     "Execute a command in a similar environment as if installation was performed."
@@ -828,11 +833,7 @@ let exec =
   in
   ( Term.(const go
           $ common
-          $ Arg.(value
-                 & opt string "default"
-                 & info ["context"] ~docv:"CONTEXT"
-                     ~doc:{|Run the command in this build context.|}
-                )
+          $ context_arg ~doc:{|Run the command in this build context.|}
           $ Arg.(required
                  & pos 0 (some string) None (Arg.info [] ~docv:"PROG"))
           $ Arg.(value
@@ -931,10 +932,7 @@ let utop =
   ( Term.(const go
           $ common
           $ Arg.(value & pos 0 dir "" name_)
-          $ Arg.(value
-                 & opt string "default"
-                 & info ["context"] ~docv:"CONTEXT"
-                     ~doc:{|Select context where to build/run utop.|})
+          $ context_arg ~doc:{|Select context where to build/run utop.|}
           $ Arg.(value & pos_right 0 string [] (Arg.info [] ~docv:"ARGS")))
   , Term.info "utop" ~doc ~man )
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -912,17 +912,7 @@ let utop =
     let log = Log.create () in
     let (build_system, context, utop_path) =
       (Main.setup ~log common >>= fun setup ->
-       let context =
-         match ctx_name, setup.contexts with
-         | None, [c] -> c
-         | None, [] -> die "No contexts discovered"
-         | None, ctxs ->
-           die "Specify a --context argument to disambiguate contexts.\
-                @.Available contexts: %s"
-             (ctxs
-             |> List.map ~f:(fun c -> c.Context.name)
-             |> String.concat ~sep:",")
-         | Some name, _ -> Main.find_context_exn setup ~name in
+       let context = Main.find_context_exn setup ~name:ctx_name in
        let setup = { setup with contexts = [context] } in
        let target =
          match resolve_targets ~log common setup [utop_target] with
@@ -941,8 +931,10 @@ let utop =
   ( Term.(const go
           $ common
           $ Arg.(value & pos 0 dir "" name_)
-          $ Arg.(value & opt (some string) None &
-                 info ["context"] ~doc:{|Select context where to build/run utop.|})
+          $ Arg.(value
+                 & opt string "default"
+                 & info ["context"] ~docv:"CONTEXT"
+                     ~doc:{|Select context where to build/run utop.|})
           $ Arg.(value & pos_right 0 string [] (Arg.info [] ~docv:"ARGS")))
   , Term.info "utop" ~doc ~man )
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -814,13 +814,7 @@ let exec =
     set_common common ~targets:[];
     let log = Log.create () in
     let setup = Future.Scheduler.go ~log (Main.setup ~log common) in
-    let context =
-      match List.find setup.contexts ~f:(fun c -> c.name = context) with
-      | Some ctx -> ctx
-      | None ->
-        Format.eprintf "@{<Error>Error@}: Context %S not found!@." context;
-        die ""
-    in
+    let context = Main.find_context_exn setup ~name:context in
     let path = Config.local_install_bin_dir ~context:context.name :: context.path in
     match Bin.which ~path prog with
     | None ->
@@ -924,11 +918,7 @@ let utop =
              (ctxs
              |> List.map ~f:(fun c -> c.Context.name)
              |> String.concat ~sep:",")
-         | Some name, ctxs ->
-           begin match List.find ctxs ~f:(fun ctx -> ctx.Context.name = name) with
-           | None -> die "Context %s doesn't exist" name
-           | Some c -> c
-           end in
+         | Some name, _ -> Main.find_context_exn setup ~name in
        let target =
          match resolve_targets ~log common setup [utop_target] with
          | [] -> die "no libraries defined in %s" dir

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -901,7 +901,11 @@ let subst =
 
 let utop =
   let doc = "Load library in utop" in
-  let man = [ (* TODO *) ] in
+  let man =
+    [ `S "DESCRIPTION"
+    ; `P {|$(b,jbuilder utop DIR) build and run utop toplevel with libraries defined in DIR|}
+    ; `Blocks help_secs
+    ] in
   let go common dir ctx_name args =
     let utop_target = dir |> Path.of_string |> Utop.utop_exe |> Path.to_string in
     set_common common ~targets:[utop_target];

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -572,6 +572,8 @@ let all_targets_ever_built () =
   else
     []
 
+let dump_trace t = Trace.dump t.trace
+
 let create ~contexts ~file_tree ~rules =
   let all_source_files =
     File_tree.fold file_tree ~init:Pset.empty ~f:(fun dir acc ->
@@ -615,7 +617,7 @@ let create ~contexts ~file_tree ~rules =
   setup_copy_rules t ~all_targets_by_dir
     ~all_non_target_source_files:
       (Pset.diff all_source_files all_other_targets);
-  at_exit (fun () -> Trace.dump t.trace);
+  at_exit (fun () -> dump_trace t);
   t
 
 let remove_old_artifacts t =
@@ -815,3 +817,6 @@ let build_rules t ?(recursive=false) targets =
     die "dependency cycle detected:\n   %s"
       (List.map cycle ~f:(fun rule -> Path.to_string (Pset.choose rule.Rule.targets))
        |> String.concat ~sep:"\n-> ")
+
+let dump_trace t =
+  Trace.dump t.trace

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -817,6 +817,3 @@ let build_rules t ?(recursive=false) targets =
     die "dependency cycle detected:\n   %s"
       (List.map cycle ~f:(fun rule -> Path.to_string (Pset.choose rule.Rule.targets))
        |> String.concat ~sep:"\n-> ")
-
-let dump_trace t =
-  Trace.dump t.trace

--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -66,3 +66,5 @@ val build_rules
 val all_targets_ever_built
   :  unit
   -> Path.t list
+
+val dump_trace : t -> unit

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -727,9 +727,10 @@ Add it to your jbuild file to remove this warning.
       SC.stanzas sctx
       |> List.concat_map ~f:(fun x -> x.SC.Dir_with_jbuild.stanzas) in
     Option.iter (Utop.exe_stanzas stanzas) ~f:(fun (exe, all_modules) ->
-      Utop.add_module_rules sctx ~dir:ctx_dir (Option.value_exn lib_requires);
-      let merlin = executables_rules exe ~dir:ctx_dir ~all_modules ~scope in
-      Merlin.add_rules sctx ~dir:ctx_dir merlin)
+      let dir = Utop.src_dir ctx_dir in
+      Utop.add_module_rules sctx ~dir (Option.value_exn lib_requires);
+      let merlin = executables_rules exe ~dir ~all_modules ~scope in
+      Merlin.add_rules sctx ~dir merlin)
 
   let () =
     let stanzas = SC.stanzas sctx in

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -704,29 +704,22 @@ Add it to your jbuild file to remove this warning.
       guess_modules ~dir:src_dir
         ~files:(Lazy.force files))
     in
-    let merlin =
-      List.filter_map stanzas ~f:(fun stanza ->
-        let dir = ctx_dir in
-        match (stanza : Stanza.t) with
-        | Library lib ->
-          Some (library_rules lib ~dir
-                  ~all_modules:(Lazy.force all_modules) ~files:(Lazy.force files)
-                  ~scope)
-        | Executables exes ->
-          Some (executables_rules exes ~dir ~all_modules:(Lazy.force all_modules)
-                  ~scope)
-        | _ -> None)
-      |> Merlin.merge_all in
-    Option.iter merlin ~f:(Merlin.add_rules sctx ~dir:ctx_dir);
+    List.filter_map stanzas ~f:(fun stanza ->
+      let dir = ctx_dir in
+      match (stanza : Stanza.t) with
+      | Library lib ->
+        Some (library_rules lib ~dir ~all_modules:(Lazy.force all_modules)
+                ~files:(Lazy.force files) ~scope)
+      | Executables exes ->
+        Some (executables_rules exes ~dir ~all_modules:(Lazy.force all_modules) ~scope)
+      | _ -> None)
+    |> Merlin.merge_all
+    |> Option.iter ~f:(Merlin.add_rules sctx ~dir:ctx_dir);
     Option.iter (Utop.exe_stanzas stanzas) ~f:(fun (exe, all_modules) ->
-      let dir = Utop.utop_exe_dir ~dir:ctx_dir in let merlin' = executables_rules exe ~dir ~all_modules ~scope in
-      Merlin.add_rules sctx ~dir merlin';
-      (* so that our uutop.ml module depends on the libraries that in our
-         current jbuild dir. We could also just pass the current jbuild dir
-         explicitly *)
-      let lib_requires =
-        (Merlin.merge_two (Option.value_exn merlin) merlin').requires in
-      Utop.add_module_rules sctx ~dir lib_requires;
+      let dir = Utop.utop_exe_dir ~dir:ctx_dir in
+      let merlin = executables_rules exe ~dir ~all_modules ~scope in
+      Merlin.add_rules sctx ~dir merlin;
+      Utop.add_module_rules sctx ~dir merlin.requires;
     )
 
   let () = List.iter (SC.stanzas sctx) ~f:rules

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -708,18 +708,17 @@ Add it to your jbuild file to remove this warning.
       List.filter_map stanzas ~f:(fun stanza ->
         let dir = ctx_dir in
         match (stanza : Stanza.t) with
-        | Library lib  ->
+        | Library lib ->
           Some (library_rules lib ~dir
                   ~all_modules:(Lazy.force all_modules) ~files:(Lazy.force files)
                   ~scope)
-        | Executables  exes ->
+        | Executables exes ->
           Some (executables_rules exes ~dir ~all_modules:(Lazy.force all_modules)
                   ~scope)
         | _ -> None)
       |> Merlin.merge_all in
     Option.iter merlin ~f:(Merlin.add_rules sctx ~dir:ctx_dir);
     Option.map merlin ~f:(fun m -> m.Merlin.requires)
-  ;;
 
   let utop_rules lib_requires =
     let ctx_dir = (SC.context sctx).build_dir in
@@ -730,8 +729,7 @@ Add it to your jbuild file to remove this warning.
     Option.iter (Utop.exe_stanzas stanzas) ~f:(fun (exe, all_modules) ->
       Utop.add_module_rules sctx ~dir:ctx_dir (Option.value_exn lib_requires);
       let merlin = executables_rules exe ~dir:ctx_dir ~all_modules ~scope in
-      Merlin.add_rules sctx ~dir:ctx_dir merlin
-    )
+      Merlin.add_rules sctx ~dir:ctx_dir merlin)
 
   let () =
     let stanzas = SC.stanzas sctx in
@@ -742,7 +740,7 @@ Add it to your jbuild file to remove this warning.
       | Some r, Some r' ->
         Some (Build.fanout r r' >>^ fun (x, y) -> Lib.remove_dups_preserve_order (x @ y)))
     in
-    utop_rules  lib_requires
+    utop_rules lib_requires
   let () =
     SC.add_rules sctx (Js_of_ocaml_rules.setup_separate_compilation_rules sctx)
   let () = Odoc.setup_css_rule sctx

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -715,7 +715,13 @@ Add it to your jbuild file to remove this warning.
         Some (executables_rules exes ~dir ~all_modules:(Lazy.force all_modules)
                 ~scope)
       | _ -> None)
-    |> Merlin.add_rules sctx ~dir:ctx_dir
+    |> Merlin.add_rules sctx ~dir:ctx_dir;
+    Utop.add_rules sctx ~dir:ctx_dir stanzas
+    |> Option.iter ~f:(fun (stanza, all_modules) ->
+      (* there's no need to generate a .merlin file for this exe *)
+      ignore (executables_rules stanza ~dir:ctx_dir ~all_modules ~scope)
+    )
+  ;;
 
   let () = List.iter (SC.stanzas sctx) ~f:rules
   let () =

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -719,8 +719,7 @@ Add it to your jbuild file to remove this warning.
       |> Merlin.merge_all in
     Option.iter merlin ~f:(Merlin.add_rules sctx ~dir:ctx_dir);
     Option.iter (Utop.exe_stanzas stanzas) ~f:(fun (exe, all_modules) ->
-      let dir = Utop.src_dir ctx_dir in
-      let merlin' = executables_rules exe ~dir ~all_modules ~scope in
+      let dir = Utop.utop_exe_dir ~dir:ctx_dir in let merlin' = executables_rules exe ~dir ~all_modules ~scope in
       Merlin.add_rules sctx ~dir merlin';
       (* so that our uutop.ml module depends on the libraries that in our
          current jbuild dir. We could also just pass the current jbuild dir

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -282,6 +282,8 @@ module Preprocess_map = struct
   type t = Preprocess.t Per_module.t
   let t = Per_module.t Preprocess.t
 
+  let no_preprocessing = Per_module.For_all Preprocess.No_preprocessing
+
   let find module_name (t : t) =
     match t with
     | For_all pp -> pp

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -46,6 +46,9 @@ end
 module Preprocess_map : sig
   type t
 
+  val no_preprocessing : t
+  val default : t
+
   (** [find module_name] find the preprocessing specification for a given module *)
   val find : string -> t -> Preprocess.t
 
@@ -57,6 +60,8 @@ module Js_of_ocaml : sig
     { flags            : Ordered_set_lang.Unexpanded.t
     ; javascript_files : string list
     }
+
+  val default : t
 end
 
 module Lib_dep : sig

--- a/src/main.ml
+++ b/src/main.ml
@@ -220,3 +220,10 @@ let bootstrap () =
     exit 1
 
 let setup = setup ~use_findlib:true ~extra_ignored_subtrees:Path.Set.empty
+
+let find_context_exn t ~name =
+  match List.find t.contexts ~f:(fun c -> c.name = name) with
+  | Some ctx -> ctx
+  | None ->
+    Format.eprintf "@{<Error>Error@}: Context %S not found!@." name;
+    die ""

--- a/src/main.mli
+++ b/src/main.mli
@@ -28,3 +28,5 @@ val external_lib_deps
 val report_error : ?map_fname:(string -> string) -> Format.formatter -> exn -> unit
 
 val bootstrap : unit -> unit
+
+val find_context_exn : setup -> name:string -> Context.t

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -99,8 +99,10 @@ let merge_two a b =
       | None -> b.libname
   }
 
-let add_rules sctx ~dir ts =
+let merge_all = function
+  | [] -> None
+  | init::ts -> Some (List.fold_left ~init ~f:merge_two ts)
+
+let add_rules sctx ~dir merlin =
   if (SC.context sctx).merlin then
-    match ts with
-    | [] -> ()
-    | t :: ts -> dot_merlin sctx ~dir (List.fold_left ts ~init:t ~f:merge_two)
+    dot_merlin sctx ~dir merlin

--- a/src/merlin.mli
+++ b/src/merlin.mli
@@ -7,6 +7,8 @@ type t =
   ; libname    : string option
   }
 
+val merge_two : t -> t -> t
+
 val merge_all : t list -> t option
 
 (** Add rules for generating the .merlin in a directory and return

--- a/src/merlin.mli
+++ b/src/merlin.mli
@@ -11,7 +11,6 @@ val merge_two : t -> t -> t
 
 val merge_all : t list -> t option
 
-(** Add rules for generating the .merlin in a directory and return
-    the final .merlin used *)
+(** Add rules for generating the .merlin in a directory *)
 val add_rules : Super_context.t -> dir:Path.t -> t -> unit
 

--- a/src/merlin.mli
+++ b/src/merlin.mli
@@ -7,6 +7,9 @@ type t =
   ; libname    : string option
   }
 
-(** Add rules for generating the .merlin in a directory *)
-val add_rules : Super_context.t -> dir:Path.t -> t list -> unit
+val merge_all : t list -> t option
+
+(** Add rules for generating the .merlin in a directory and return
+    the final .merlin used *)
+val add_rules : Super_context.t -> dir:Path.t -> t -> unit
 

--- a/src/merlin.mli
+++ b/src/merlin.mli
@@ -7,8 +7,6 @@ type t =
   ; libname    : string option
   }
 
-val merge_two : t -> t -> t
-
 val merge_all : t list -> t option
 
 (** Add rules for generating the .merlin in a directory *)

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -1,0 +1,87 @@
+open Import
+open Jbuild
+open Build.O
+open! No_io
+
+let exe_name = "uutop"
+let module_name = String.capitalize_ascii exe_name
+let module_filename = exe_name ^ ".ml"
+
+let pp_ml fmt include_dirs =
+  let pp_include fmt l =
+    let pp_sep fmt () = Format.fprintf fmt "@.;@ " in
+    Format.pp_print_list ~pp_sep (fun fmt p ->
+      Format.fprintf fmt {|"%s"|} (Path.to_string p)
+    ) fmt l
+  in
+  Format.fprintf fmt "Clflags.include_dirs := [@[<2>@.%a@.];@."
+    pp_include include_dirs;
+  Format.fprintf fmt "UTop_main.main ();@."
+
+let add_utop_module_rule sctx ~dir include_dirs =
+  let path = Path.relative dir module_filename in
+  let utop_ml =
+    Build.return (
+      let b = Buffer.create 64 in
+      let fmt = Format.formatter_of_buffer b in
+      pp_ml fmt include_dirs;
+      Format.pp_print_flush fmt ();
+      Buffer.contents b
+    )
+    >>> Build.update_file_dyn path
+  in
+  Super_context.add_rule sctx utop_ml
+
+let utop_of_libs (libs : Library.t list) =
+  { Executables.names = [exe_name]
+  ; link_executables = true
+  ; link_flags = ["-linkall"]
+  ; modes = Mode.Dict.Set.of_list [Mode.Byte]
+  ; buildable =
+      { Buildable.modules =
+          Ordered_set_lang.t (List (Loc.none, [Atom (Loc.none, module_name)]))
+      ; libraries =
+          (Lib_dep.direct "utop") :: (List.map libs ~f:(fun lib ->
+            Lib_dep.direct lib.Library.name))
+      ; preprocess = Preprocess_map.no_preprocessing
+      ; preprocessor_deps = []
+      ; flags = Ordered_set_lang.standard
+      ; ocamlc_flags = Ordered_set_lang.standard
+      ; ocamlopt_flags = Ordered_set_lang.standard
+      ; js_of_ocaml = Js_of_ocaml.default
+      }
+  }
+
+let add_rules sctx ~dir stanzas =
+  let libs =
+    List.filter_map stanzas ~f:(function
+      | Stanza.Library lib -> Some lib
+      | _ -> None
+    ) in
+  match libs with
+  | [] -> None
+  | libs ->
+    let all_modules =
+      String_map.of_alist_exn
+        [ module_name
+        , { Module.
+            name = module_name
+          ; impl = { Module.File.
+                     name = module_filename
+                   ; syntax = Module.Syntax.OCaml
+                   }
+          ; intf = None
+          ; obj_name = "" }
+        ] in
+    add_utop_module_rule sctx ~dir [dir];
+    Some (utop_of_libs libs, all_modules)
+
+let target stanzas lib_name =
+  stanzas
+  |> List.find_map ~f:(fun (p, _, stanzas) ->
+    stanzas
+    |> List.find ~f:(function
+      | Jbuild.Stanza.Library l -> Lib.best_name (Lib.Internal (p, l)) = lib_name
+      | _ -> false)
+    |> Option.map ~f:(fun _ -> p))
+  |> Option.map ~f:(fun p -> Path.relative p "uutop.bc")

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -75,6 +75,8 @@ let exe_stanzas stanzas =
         ] in
     Some (utop_of_libs libs, all_modules)
 
+let src_dir p = Path.relative p ".utop"
+
 let target context =
-  Path.relative context.Context.build_dir exe_name
+  Path.relative (src_dir context.Context.build_dir) exe_name
   |> Path.extend_basename ~suffix:(Mode.exe_ext Mode.Byte)

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -77,7 +77,6 @@ let exe_stanzas stanzas =
 
 let src_dir p = Path.relative p ".utop"
 
-let target context jbuild_p =
-  let utop_dir = Path.append context.Context.build_dir (src_dir jbuild_p) in
-  Path.relative utop_dir exe_name
+let target jbuild_p =
+  Path.relative (src_dir jbuild_p) exe_name
   |> Path.extend_basename ~suffix:(Mode.exe_ext Mode.Byte)

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -18,18 +18,18 @@ let pp_ml fmt include_dirs =
     pp_include include_dirs;
   Format.fprintf fmt "UTop_main.main ();@."
 
-let add_utop_module_rule sctx ~dir include_dirs =
+let add_module_rules sctx ~dir lib_requires =
   let path = Path.relative dir module_filename in
   let utop_ml =
-    Build.return (
+    lib_requires
+    >>^ (fun libs ->
+      let include_paths = dir :: (Path.Set.elements (Lib.include_paths libs)) in
       let b = Buffer.create 64 in
       let fmt = Format.formatter_of_buffer b in
-      pp_ml fmt include_dirs;
+      pp_ml fmt include_paths;
       Format.pp_print_flush fmt ();
-      Buffer.contents b
-    )
-    >>> Build.update_file_dyn path
-  in
+      Buffer.contents b)
+    >>> Build.update_file_dyn path in
   Super_context.add_rule sctx utop_ml
 
 let utop_of_libs (libs : Library.t list) =
@@ -52,7 +52,7 @@ let utop_of_libs (libs : Library.t list) =
       }
   }
 
-let add_rules sctx ~dir stanzas =
+let exe_stanzas stanzas =
   let libs =
     List.filter_map stanzas ~f:(function
       | Stanza.Library lib -> Some lib
@@ -73,7 +73,6 @@ let add_rules sctx ~dir stanzas =
           ; intf = None
           ; obj_name = "" }
         ] in
-    add_utop_module_rule sctx ~dir [dir];
     Some (utop_of_libs libs, all_modules)
 
 let target stanzas lib_name =

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -35,7 +35,9 @@ let add_module_rules sctx ~dir lib_requires =
 let utop_of_libs (libs : Library.t list) =
   { Executables.names = [exe_name]
   ; link_executables = true
-  ; link_flags = ["-linkall"]
+  ; link_flags = Ordered_set_lang.Unexpanded.t (
+      Sexp.add_loc ~loc:Loc.none (List [Atom "-linkall"])
+    )
   ; modes = Mode.Dict.Set.of_list [Mode.Byte]
   ; buildable =
       { Buildable.modules =
@@ -45,9 +47,9 @@ let utop_of_libs (libs : Library.t list) =
             Lib_dep.direct lib.Library.name))
       ; preprocess = Preprocess_map.no_preprocessing
       ; preprocessor_deps = []
-      ; flags = Ordered_set_lang.standard
-      ; ocamlc_flags = Ordered_set_lang.standard
-      ; ocamlopt_flags = Ordered_set_lang.standard
+      ; flags = Ordered_set_lang.Unexpanded.standard
+      ; ocamlc_flags = Ordered_set_lang.Unexpanded.standard
+      ; ocamlopt_flags = Ordered_set_lang.Unexpanded.standard
       ; js_of_ocaml = Js_of_ocaml.default
       }
   }

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -83,4 +83,6 @@ let target stanzas lib_name =
       | Jbuild.Stanza.Library l -> Lib.best_name (Lib.Internal (p, l)) = lib_name
       | _ -> false)
     |> Option.map ~f:(fun _ -> p))
-  |> Option.map ~f:(fun p -> Path.relative p "uutop.bc")
+  |> Option.map ~f:(fun p ->
+    Path.relative p exe_name
+    |> Path.extend_basename ~suffix:(Mode.exe_ext Mode.Byte))

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -75,8 +75,8 @@ let exe_stanzas stanzas =
         ] in
     Some (utop_of_libs libs, all_modules)
 
-let src_dir p = Path.relative p ".utop"
+let utop_exe_dir ~dir = Path.relative dir ".utop"
 
-let target jbuild_p =
-  Path.relative (src_dir jbuild_p) exe_name
+let utop_exe dir =
+  Path.relative (utop_exe_dir ~dir) exe_name
   |> Path.extend_basename ~suffix:(Mode.exe_ext Mode.Byte)

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -3,7 +3,7 @@ open Jbuild
 open Build.O
 open! No_io
 
-let exe_name = "uutop"
+let exe_name = "utop"
 let module_name = String.capitalize_ascii exe_name
 let module_filename = exe_name ^ ".ml"
 

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -75,14 +75,6 @@ let exe_stanzas stanzas =
         ] in
     Some (utop_of_libs libs, all_modules)
 
-let target stanzas lib_name =
-  stanzas
-  |> List.find_map ~f:(fun (p, _, stanzas) ->
-    stanzas
-    |> List.find ~f:(function
-      | Jbuild.Stanza.Library l -> Lib.best_name (Lib.Internal (p, l)) = lib_name
-      | _ -> false)
-    |> Option.map ~f:(fun _ -> p))
-  |> Option.map ~f:(fun p ->
-    Path.relative p exe_name
-    |> Path.extend_basename ~suffix:(Mode.exe_ext Mode.Byte))
+let target context =
+  Path.relative context.Context.build_dir exe_name
+  |> Path.extend_basename ~suffix:(Mode.exe_ext Mode.Byte)

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -8,15 +8,15 @@ let module_name = String.capitalize_ascii exe_name
 let module_filename = exe_name ^ ".ml"
 
 let pp_ml fmt include_dirs =
-  let pp_include fmt l =
-    let pp_sep fmt () = Format.fprintf fmt "@.;@ " in
+  let pp_include fmt =
+    let pp_sep fmt () = Format.fprintf fmt "@ ; " in
     Format.pp_print_list ~pp_sep (fun fmt p ->
       Format.fprintf fmt {|"%s"|} (Path.to_string p)
-    ) fmt l
+    ) fmt
   in
-  Format.fprintf fmt "Clflags.include_dirs := [@[<2>@.%a@.];@."
+  Format.fprintf fmt "@[<v 2>Clflags.include_dirs :=@ [ %a@ ]@];@."
     pp_include include_dirs;
-  Format.fprintf fmt "UTop_main.main ();@."
+  Format.fprintf fmt "@.UTop_main.main ();@."
 
 let add_module_rules sctx ~dir lib_requires =
   let path = Path.relative dir module_filename in

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -23,7 +23,7 @@ let add_module_rules sctx ~dir lib_requires =
   let utop_ml =
     lib_requires
     >>^ (fun libs ->
-      let include_paths = dir :: (Path.Set.elements (Lib.include_paths libs)) in
+      let include_paths = Path.Set.elements (Lib.include_paths libs) in
       let b = Buffer.create 64 in
       let fmt = Format.formatter_of_buffer b in
       pp_ml fmt include_paths;
@@ -77,6 +77,7 @@ let exe_stanzas stanzas =
 
 let src_dir p = Path.relative p ".utop"
 
-let target context =
-  Path.relative (src_dir context.Context.build_dir) exe_name
+let target context jbuild_p =
+  let utop_dir = Path.append context.Context.build_dir (src_dir jbuild_p) in
+  Path.relative utop_dir exe_name
   |> Path.extend_basename ~suffix:(Mode.exe_ext Mode.Byte)

--- a/src/utop.mli
+++ b/src/utop.mli
@@ -10,6 +10,6 @@ val add_module_rules
   -> (unit, Lib.t list) Build.t
   -> unit
 
-val src_dir : Path.t -> Path.t
+val utop_exe_dir : dir:Path.t -> Path.t
 
-val target : Path.t -> Path.t
+val utop_exe : Path.t -> Path.t

--- a/src/utop.mli
+++ b/src/utop.mli
@@ -12,4 +12,4 @@ val add_module_rules
 
 val src_dir : Path.t -> Path.t
 
-val target : Context.t -> Path.t -> Path.t
+val target : Path.t -> Path.t

--- a/src/utop.mli
+++ b/src/utop.mli
@@ -12,4 +12,4 @@ val add_module_rules
 
 val src_dir : Path.t -> Path.t
 
-val target : Context.t -> Path.t
+val target : Context.t -> Path.t -> Path.t

--- a/src/utop.mli
+++ b/src/utop.mli
@@ -1,0 +1,11 @@
+
+val add_rules
+  : Super_context.t
+  -> dir:Path.t
+  -> Jbuild.Stanza.t list
+  -> (Jbuild.Executables.t * Module.t Import.String_map.t) option
+
+val target
+  : (Path.t * Jbuild.Scope.t * Jbuild.Stanzas.t) list
+  -> string
+  -> Path.t option

--- a/src/utop.mli
+++ b/src/utop.mli
@@ -1,15 +1,26 @@
+(** Utop rules *)
+
 open Import
 
 val exe_stanzas
   : Jbuild.Stanza.t list
   -> (Jbuild.Executables.t * Module.t String_map.t) option
+(** Given a list of stanzas (from a directory with a jbuild file) return:
+    1. a stanza for a utop toplevel with all the libraries linked in.
+    2. an entry module that will be used to create the toplevel *)
 
 val add_module_rules
   : Super_context.t
   -> dir:Path.t
   -> (unit, Lib.t list) Build.t
   -> unit
+(** Add rules to generate a utop module that will all have all the include dirs
+    for the dependencies *)
 
 val utop_exe_dir : dir:Path.t -> Path.t
+(** Return the directory in which the main module for the top level will be
+    generated. *)
 
 val utop_exe : Path.t -> Path.t
+(** Return the path of the utop bytecode binary inside a directory where
+    some libraries are defined. *)

--- a/src/utop.mli
+++ b/src/utop.mli
@@ -1,9 +1,14 @@
+open Import
 
-val add_rules
+val exe_stanzas
+  : Jbuild.Stanza.t list
+  -> (Jbuild.Executables.t * Module.t String_map.t) option
+
+val add_module_rules
   : Super_context.t
   -> dir:Path.t
-  -> Jbuild.Stanza.t list
-  -> (Jbuild.Executables.t * Module.t Import.String_map.t) option
+  -> (unit, Lib.t list) Build.t
+  -> unit
 
 val target
   : (Path.t * Jbuild.Scope.t * Jbuild.Stanzas.t) list

--- a/src/utop.mli
+++ b/src/utop.mli
@@ -10,7 +10,4 @@ val add_module_rules
   -> (unit, Lib.t list) Build.t
   -> unit
 
-val target
-  : (Path.t * Jbuild.Scope.t * Jbuild.Stanzas.t) list
-  -> string
-  -> Path.t option
+val target : Context.t -> Path.t

--- a/src/utop.mli
+++ b/src/utop.mli
@@ -10,4 +10,6 @@ val add_module_rules
   -> (unit, Lib.t list) Build.t
   -> unit
 
+val src_dir : Path.t -> Path.t
+
 val target : Context.t -> Path.t


### PR DESCRIPTION
Accepts a library name as input and builds and runs utop which loads the given
library.

Here's an attempt at #114. Some comments and questions:

* How would I use .utop.ml as you recommended? It's not a valid module name.

* ~~For now, I've used `uutop.ml` as a workaround, which is not satisfying. In particular, I'm kind of worried that this will interfere with current builds by adding this uutop.ml file which might be included in globs in later builds. Would it make sense to add a separate directory for these utop binaries to solve
these issues? Right now, I'm relying on the fact that I'm defining the utop rules after defining all other rules which seems to work but seems hacky.~~

EDIT: The uutop.ml now exists in its own directory, so this isn't an issue.

* Currently, I'm creating a single utop binary for all the libraries in a directory, why is that? Can't we create a separate top level for every library?

* I ended up not using build_exe directly and just constructing an executable stanza and getting the build rules from that. I just found that easier to implement because I wasn't sure which params to pass to build_exe. Feel free to help here if you want to use build_exe directly.

* ~~There's a weird issue with rebuilds that can be triggered by launching a utop instance with `$ _build/default/bin/main.exe utop jbuilder` and then doing a build, I get this bizarre error:~~

EDIT: This  issue was solved when I fixed the at_exit hooks not being ran issue.

```
./boot.exe -j 4 --dev
      ocamlc bin/main.{cmi,cmti}
    ocamlopt vendor/re/src/jbuilder_re.{cmx,o}
    ocamlopt src/jbuilder.{cmx,o}
    ocamlopt vendor/opam-file-format/src/jbuilder_opam_file_format.{cmx,o}
    ocamlopt vendor/re/src/jbuilder_re__Re_fmt.{cmx,o} (exit 2)
(cd _build/default && /home/rgrinberg/.opam/4.04.1/bin/ocamlopt.opt -w @a-4-29-40-41-42-44-45-48-58-59-60-40 -strict-sequence -strict-formats -short-paths -keep-locs -w -50 -g -intf-suffix .ml -no-alias-deps -I vendor/re/src -open Jbuilder_re -o vendor/re/src/jbuilder_re__Re_fmt.cmx -c -impl vendor/re/src/re_fmt.ml)
File "vendor/re/src/re_fmt.ml", line 1:
Error: The implementation vendor/re/src/re_fmt.ml
       does not match the interface vendor/re/src/jbuilder_re__Re_fmt.cmi:
       Values do not match:
         val pair :
           (formatter -> 'a -> unit) ->
           (formatter -> 'b -> 'c) -> formatter -> 'a * 'b -> 'c
       is not included in
         val pair :
           (formatter -> 'a -> 'b) ->
           (formatter -> 'c -> 'd) -> formatter -> 'a * 'c -> 'd
       File "vendor/re/src/re_fmt.ml", line 16, characters 4-8:
         Actual declaration
make: *** [Makefile:5: default] Error 1

```

Other TODOs:

- [x] I also need to calculate the `-I` flags of *all* the libraries we depend on. Right now, it will be possible to only use the library explicitly loaded rather. There's no access to its dependencies.

- [x] Currently `$ jbuilder utop` seems to recompile what it did compiled on on the previous invocation every time. I don't know why this is because building the `uutop.bc` with `$ jbuilder build` doesn't exhibit this problem. Is it because of how I'm calling Unix.exec?

EDIT: Indeed it is. We must careful and wait for all the exit hooks to run before execing.