### PR TITLE
Use greedy extension for -intf-suffix

### DIFF
--- a/src/import.ml
+++ b/src/import.ml
@@ -363,6 +363,13 @@ module Filename = struct
   let extension fn =
     let i = extension_start fn in
     String.sub fn ~pos:i ~len:(String.length fn - i)
+
+  (* test.x.y.z -> .x.y.z *)
+  let rec greedy_extension fn =
+    match split_extension fn with
+    | _, "" -> ""
+    | (f, e) when extension f = "" -> e
+    | (f, e) -> greedy_extension f ^ "." ^ e
 end
 
 module Option = struct

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -23,7 +23,7 @@ let build_cm sctx ?sandbox ~dynlink ~flags ~cm_kind ~(dep_graph:Ocamldep.dep_gra
              cmi exists and reads it instead of re-creating it, which
              could create a race condition. *)
           ([ "-intf-suffix"
-           ; Filename.extension m.impl.name
+           ; Filename.greedy_extension m.impl.name
            ],
            [Module.cm_file m ~dir Cmi], [])
         | Cmi, None -> assert false


### PR DESCRIPTION
Since reason sources are named as .{re,rei}.{ml,mli}

Fix #184