### PR TITLE
Use the full path of archives when linking

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 - Fix the quoting of `FLG` lines in generated `.merlin` files (#200,
   Marcello Seri)
 
+- Use the full path of archive files when linking. Before jbuilder
+  would do: `-I <path> file.cmxa`, now it does `-I <path>
+  <path>/file.cmxa`. Fixes #118 and #177
+
 1.0+beta11 (21/07/2017)
 -----------------------
 

--- a/src/arg_spec.ml
+++ b/src/arg_spec.ml
@@ -8,8 +8,6 @@ type 'a t =
   | S        of 'a t list
   | Dep      of Path.t
   | Deps     of Path.t list
-  | Dep_rel  of Path.t * string
-  | Deps_rel of Path.t * string list
   | Target   of Path.t
   | Path     of Path.t
   | Paths    of Path.t list
@@ -20,10 +18,6 @@ let rec add_deps ts set =
     match t with
     | Dep  fn  -> Pset.add fn set
     | Deps fns -> Pset.union set (Pset.of_list fns)
-    | Dep_rel  (dir, fn) -> Pset.add (Path.relative dir fn) set
-    | Deps_rel (dir, fns) ->
-      List.fold_left fns ~init:set ~f:(fun set fn ->
-        Pset.add (Path.relative dir fn) set)
     | S ts -> add_deps ts set
     | _ -> set)
 
@@ -40,12 +34,6 @@ let expand ~dir ts x =
   let rec loop_dyn : nothing t -> string list = function
     | A s  -> [s]
     | As l -> l
-    | Dep_rel (dir, fn) ->
-      add_dep (Path.relative dir fn);
-      [fn]
-    | Deps_rel (dir, fns) ->
-      List.iter fns ~f:(fun fn -> add_dep (Path.relative dir fn));
-      fns
     | Dep fn ->
       add_dep fn;
       [Path.reach fn ~from:dir]
@@ -63,8 +51,6 @@ let expand ~dir ts x =
   let rec loop = function
     | A s  -> [s]
     | As l -> l
-    | Dep_rel (_, fn) -> [fn]
-    | Deps_rel (_, fns) -> fns
     | (Dep fn | Path fn) -> [Path.reach fn ~from:dir]
     | (Deps fns | Paths fns) -> List.map fns ~f:(Path.reach ~from:dir)
     | S ts -> List.concat_map ts ~f:loop

--- a/src/arg_spec.mli
+++ b/src/arg_spec.mli
@@ -6,8 +6,6 @@ type 'a t =
   | S        of 'a t list
   | Dep      of Path.t (** A path that is a dependency *)
   | Deps     of Path.t list
-  | Dep_rel  of Path.t * string
-  | Deps_rel of Path.t * string list
   | Target   of Path.t
   | Path     of Path.t
   | Paths    of Path.t list

--- a/src/findlib.ml
+++ b/src/findlib.ml
@@ -123,8 +123,8 @@ type package =
   ; dir              : Path.t
   ; version          : string
   ; description      : string
-  ; archives         : string list Mode.Dict.t
-  ; plugins          : string list Mode.Dict.t
+  ; archives         : Path.t list Mode.Dict.t
+  ; plugins          : Path.t list Mode.Dict.t
   ; jsoo_runtime     : string list
   ; requires         : package list
   ; ppx_runtime_deps : package list
@@ -238,7 +238,8 @@ let parse_package t ~name ~parent_dir ~vars ~required_by =
   in
   let archives var preds =
     Mode.Dict.of_func (fun ~mode ->
-      Vars.get_words vars var (Mode.findlib_predicate mode :: preds))
+      List.map (Vars.get_words vars var (Mode.findlib_predicate mode :: preds))
+        ~f:(Path.relative dir))
   in
   let jsoo_runtime = Vars.get_words vars "jsoo_runtime" [] in
   let preds = ["ppx_driver"; "mt"; "mt_posix"] in
@@ -557,7 +558,8 @@ let all_unavailable_packages t =
 let stdlib_with_archives t =
   let x = find_exn t ~required_by:[] "stdlib" in
   let archives =
-    { Mode.Dict.byte   = "stdlib.cma"  :: x.archives.byte
-    ; Mode.Dict.native = "stdlib.cmxa" :: x.archives.native }
+    { Mode.Dict.byte   = Path.relative x.dir "stdlib.cma"  :: x.archives.byte
+    ; Mode.Dict.native = Path.relative x.dir "stdlib.cmxa" :: x.archives.native
+    }
   in
   { x with archives }

--- a/src/findlib.mli
+++ b/src/findlib.mli
@@ -50,8 +50,8 @@ type package =
   ; dir              : Path.t
   ; version          : string
   ; description      : string
-  ; archives         : string list Mode.Dict.t
-  ; plugins          : string list Mode.Dict.t
+  ; archives         : Path.t list Mode.Dict.t
+  ; plugins          : Path.t list Mode.Dict.t
   ; jsoo_runtime     : string list
   ; requires         : package list
   ; ppx_runtime_deps : package list

--- a/src/jbuild_load.ml
+++ b/src/jbuild_load.ml
@@ -123,7 +123,7 @@ end
           List.concat
             [ [ "-I"; "+compiler-libs" ]
             ; includes
-            ; cmas
+            ; List.map cmas ~f:(Path.reach ~from:dir)
             ; [ Path.reach ~from:dir wrapper ]
             ]
         in

--- a/src/js_of_ocaml_rules.ml
+++ b/src/js_of_ocaml_rules.ml
@@ -69,8 +69,8 @@ let link_rule ~sctx ~dir ~runtime ~target =
     let all_libs =
       List.concat_map (stdlib :: libs) ~f:(function
         | Lib.External pkg ->
-          List.map (Mode.Dict.get pkg.archives Mode.Byte) ~f:(fun name ->
-            in_build_dir ~ctx [pkg.name; sprintf "%s.js" name])
+          List.map (Mode.Dict.get pkg.archives Mode.Byte) ~f:(fun fn ->
+            in_build_dir ~ctx [pkg.name; sprintf "%s.js" (Path.basename fn)])
         | Lib.Internal (dir, lib) ->
           [ Path.relative dir (sprintf "%s.cma.js" lib.name) ]
       )
@@ -120,7 +120,8 @@ let setup_separate_compilation_rules sctx =
     in
     List.concat_map all_pkg
       ~f:(fun (pkg_name,pkg_dir,archives) ->
-        List.map archives ~f:(fun name ->
+        List.map archives ~f:(fun fn ->
+          let name = Path.basename fn in
           let src = Path.relative pkg_dir name in
           let target = in_build_dir ~ctx [ pkg_name; sprintf "%s.js" name] in
           let dir = in_build_dir ~ctx [ pkg_name ] in

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -58,14 +58,14 @@ let link_flags ts ~mode =
      List.map ts ~f:(fun t ->
        match t with
        | External pkg ->
-         Arg_spec.Deps_rel (pkg.dir, Mode.Dict.get pkg.archives mode)
+         Arg_spec.Deps (Mode.Dict.get pkg.archives mode)
        | Internal (dir, lib) ->
-         Dep_rel (dir, lib.name ^ Mode.compiled_lib_ext mode)))
+         Dep (Path.relative dir (lib.name ^ Mode.compiled_lib_ext mode))))
 
 let archive_files ts ~mode ~ext_lib =
   List.concat_map ts ~f:(function
     | External pkg ->
-      List.map (Mode.Dict.get pkg.archives mode) ~f:(Path.relative pkg.dir)
+      Mode.Dict.get pkg.archives mode
     | Internal (dir, lib) ->
       let l =
         [Path.relative dir (lib.name ^ Mode.compiled_lib_ext mode)]


### PR DESCRIPTION
Instead of passing `-I <path> file.cma` to the compiler, pass `-I <path> <path>/file.cma`.

Fixes #118 and #177.

Using the full path should also be slightly faster as the compiler won't have to do the lookup through all include paths. The only drawback is that it makes linking command line slightly longer, maybe that's a problem for Windows (cc @dra27).