### PR TITLE
Preserve quotes on certain flags that contain spaces

### DIFF
--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -55,7 +55,9 @@ let dot_merlin sctx ~dir ({ requires; flags; _ } as t) =
         let flags =
           match flags with
           | [] -> []
-          | _  -> ["FLG " ^ String.concat flags ~sep:" "]
+          | _  ->
+            let escaped_flags = List.map ~f:quote_for_shell flags in
+            ["FLG " ^ String.concat escaped_flags ~sep:" "]
         in
         let dot_merlin =
           List.concat


### PR DESCRIPTION
This is useful, for example, if one needs to pass specific  flags
by hand (due to the need to use old libraries for example).  Fixes
https://github.com/janestreet/jbuilder/issues/198

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>