### PR TITLE
Use absolute paths for ppx drivers in .merlin files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
   would do: `-I <path> file.cmxa`, now it does `-I <path>
   <path>/file.cmxa`. Fixes #118 and #177
 
+- Use an absolute path for ppx drivers in `.merlin` files. Merlin
+  <3.0.0 used to run ppx commands from the directory where the
+  `.merlin` was present but this is no longer the case
+
 1.0+beta11 (21/07/2017)
 -----------------------
 

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -11,12 +11,15 @@ type t =
   ; libname    : string option
   }
 
-let ppx_flags sctx ~dir ~src_dir { preprocess; libname; _ } =
+(* This must be forced after we change the cwd to the workspace root *)
+let root_absolute_name = lazy (Sys.getcwd ())
+
+let ppx_flags sctx ~dir ~src_dir:_ { preprocess; libname; _ } =
   match preprocess with
   | Pps { pps; flags } ->
     let exe = SC.PP.get_ppx_driver sctx pps ~dir ~dep_kind:Optional in
     let command =
-      List.map (Path.reach exe ~from:src_dir
+      List.map (Filename.concat (Lazy.force root_absolute_name) (Path.to_string exe)
                 :: "--as-ppx"
                 :: SC.PP.cookie_library_name libname
                 @ flags)


### PR DESCRIPTION
This should make .merlin files generated by jbuilder compatible with merlin < 3.0.0 and >= 3.0.0

Fixes #196 and #199 