### PR TITLE
[WIP] use digest of file contents to detect changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,12 @@
 - Get rid of the `deprecated-ppx-method` findlib package for ppx
   rewriters (#222, fixes #163)
 
+- Use digests (MD5) of files contents to detect changes rather than
+  just looking at the timestamps. We still use timestamps to avoid
+  recomputing digests. The performance difference is negligible and we
+  avoid more useless recompilations, especially when switching branches
+  for instance (#209, fixes #158)
+
 1.0+beta11 (21/07/2017)
 -----------------------
 

--- a/doc/jbuild.rst
+++ b/doc/jbuild.rst
@@ -927,6 +927,7 @@ The following constructions are available:
   ``<outputs>`` is one of: ``stdout``, ``stderr`` or ``outputs``
 - ``(progn <DSL>...)`` to execute several commands in sequence
 - ``(echo <string>)`` to output a string on stdout
+- ``(write-file <file> <string>)`` writes ``<string>`` to ``<file>``
 - ``(cat <file>)`` to print the contents of a file to stdout
 - ``(copy <src> <dst>)`` to copy a file
 - ``(copy# <src> <dst>)`` to copy a file and add a line directive at

--- a/src/action_intf.ml
+++ b/src/action_intf.ml
@@ -24,7 +24,7 @@ module type Ast = sig
     | Copy_and_add_line_directive of path * path
     | System         of string
     | Bash           of string
-    | Update_file    of path * string
+    | Write_file     of path * string
     | Rename         of path * path
     | Remove_tree    of path
     | Mkdir          of path

--- a/src/action_intf.ml
+++ b/src/action_intf.ml
@@ -18,7 +18,6 @@ module type Ast = sig
     | Ignore         of Outputs.t * t
     | Progn          of t list
     | Echo           of string
-    | Create_file    of path
     | Cat            of path
     | Copy           of path * path
     | Symlink        of path * path

--- a/src/action_intf.ml
+++ b/src/action_intf.ml
@@ -29,5 +29,6 @@ module type Ast = sig
     | Rename         of path * path
     | Remove_tree    of path
     | Mkdir          of path
+    | Digest_files   of path list
 end
 

--- a/src/alias.ml
+++ b/src/alias.ml
@@ -133,6 +133,10 @@ let rules store ~prefixes ~tree =
     let rule =
       Build_interpret.Rule.make
         (Build.path_set deps >>>
-         Build.create_file alias.file)
+         Build.action ~targets:[alias.file]
+           (Redirect (Stdout,
+                      alias.file,
+                      Digest_files
+                        (Path.Set.elements deps))))
     in
     rule :: acc)

--- a/src/build.ml
+++ b/src/build.ml
@@ -243,13 +243,13 @@ let action_dyn ?dir ~targets () =
   | None -> action
   | Some dir -> Action.Chdir (dir, action)
 
-let update_file fn s =
-  action ~targets:[fn] (Update_file (fn, s))
+let write_file fn s =
+  action ~targets:[fn] (Write_file (fn, s))
 
-let update_file_dyn fn =
+let write_file_dyn fn =
   Targets [fn]
   >>^ fun s ->
-  Action.Update_file (fn, s)
+  Action.Write_file (fn, s)
 
 let copy ~src ~dst =
   path src >>>

--- a/src/build.ml
+++ b/src/build.ml
@@ -260,7 +260,7 @@ let symlink ~src ~dst =
   action ~targets:[dst] (Symlink (src, dst))
 
 let create_file fn =
-  action ~targets:[fn] (Create_file fn)
+  action ~targets:[fn] (Redirect (Stdout, fn, Progn []))
 
 let remove_tree dir =
   arr (fun _ -> Action.Remove_tree dir)

--- a/src/build.mli
+++ b/src/build.mli
@@ -103,10 +103,9 @@ val action_dyn
   -> unit
   -> (Action.t, Action.t) t
 
-(** Create a file with the given contents. Do not ovewrite the file if
-    it hasn't changed. *)
-val update_file : Path.t -> string -> (unit, Action.t) t
-val update_file_dyn : Path.t -> (string, Action.t) t
+(** Create a file with the given contents. *)
+val write_file : Path.t -> string -> (unit, Action.t) t
+val write_file_dyn : Path.t -> (string, Action.t) t
 
 val copy : src:Path.t -> dst:Path.t -> (unit, Action.t) t
 

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -253,7 +253,7 @@ module Build_exec = struct
       | Store_vfile (Vspec.T (fn, kind)) ->
         let file = get_file bs fn (Sexp_file kind) in
         file.data <- Some x;
-        Update_file (fn, vfile_to_string kind fn x)
+        Write_file (fn, vfile_to_string kind fn x)
       | Compose (a, b) ->
         exec dyn_deps a x |> exec dyn_deps b
       | First t ->

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -121,54 +121,17 @@ type t =
   { (* File specification by targets *)
     files      : (Path.t, File_spec.packed) Hashtbl.t
   ; contexts   : Context.t list
-  ; (* Table from target to digest of [(deps, targets, action)] *)
+  ; (* Table from target to digest of
+       [(deps (filename + contents), targets (filename only), action)] *)
     trace      : (Path.t, Digest.t) Hashtbl.t
-  ; timestamps : (Path.t, float) Hashtbl.t
   ; mutable local_mkdirs : Path.Local.Set.t
   }
 
-
 let all_targets t = Hashtbl.fold t.files ~init:[] ~f:(fun ~key ~data:_ acc -> key :: acc)
 
-let timestamp t fn =
-  match Hashtbl.find t.timestamps fn with
-  | Some _ as x -> x
-  | None ->
-    match Unix.lstat (Path.to_string fn) with
-    | exception _ -> None
-    | stat        ->
-      let ts = stat.st_mtime in
-      Hashtbl.add t.timestamps ~key:fn ~data:ts;
-      Some ts
-
-type limit_timestamp =
-  { missing_files : bool
-  ; limit         : float option
-  }
-
-let merge_timestamp t fns ~merge =
-  let init =
-    { missing_files = false
-    ; limit         = None
-    }
-  in
-  List.fold_left fns ~init
-    ~f:(fun acc fn ->
-      match timestamp t fn with
-      | None    -> { acc with missing_files = true }
-      | Some ts ->
-        { acc with
-          limit =
-            match acc.limit with
-            | None -> Some ts
-            | Some ts' -> Some (merge ts ts')
-        })
-
-let min_timestamp t fns = merge_timestamp t fns ~merge:min
-let max_timestamp t fns = merge_timestamp t fns ~merge:max
-
 let find_file_exn t file =
-  Hashtbl.find_exn t.files file ~string_of_key:(fun fn -> sprintf "%S" (Path.to_string fn))
+  Hashtbl.find_exn t.files file
+    ~string_of_key:(fun fn -> sprintf "%S" (Path.to_string fn))
     ~table_desc:(fun _ -> "<target to rule>")
 
 let is_target t file = Hashtbl.mem t.files file
@@ -390,14 +353,13 @@ let create_file_specs t targets rule ~copy_source =
 
 module Pre_rule = Build_interpret.Rule
 
-let refresh_targets_timestamps_after_rule_execution t targets =
+let clear_targets_digests_after_rule_execution targets =
   let missing =
     List.fold_left targets ~init:Pset.empty ~f:(fun acc fn ->
       match Unix.lstat (Path.to_string fn) with
       | exception _ -> Pset.add fn acc
-      | stat ->
-        let ts = stat.st_mtime in
-        Hashtbl.replace t.timestamps ~key:fn ~data:ts;
+      | (_ : Unix.stats) ->
+        Utils.Cached_digest.remove fn;
         acc)
   in
   if not (Pset.is_empty missing) then
@@ -480,7 +442,8 @@ let compile_rule t ~all_targets_by_dir ?(copy_source=false) pre_rule =
     let targets_as_list  = Pset.elements targets  in
     let hash =
       let trace =
-        (all_deps_as_list,
+        (List.map all_deps_as_list ~f:(fun fn ->
+           (fn, Utils.Cached_digest.file fn)),
          targets_as_list,
          Option.map context ~f:(fun c -> c.name),
          action)
@@ -493,7 +456,7 @@ let compile_rule t ~all_targets_by_dir ?(copy_source=false) pre_rule =
       else
         None
     in
-    let rule_changed =
+    let deps_or_rule_changed =
       List.fold_left targets_as_list ~init:false ~f:(fun acc fn ->
         match Hashtbl.find t.trace fn with
         | None ->
@@ -503,29 +466,13 @@ let compile_rule t ~all_targets_by_dir ?(copy_source=false) pre_rule =
           Hashtbl.replace t.trace ~key:fn ~data:hash;
           acc || prev_hash <> hash)
     in
-    let targets_min_ts = min_timestamp t targets_as_list  in
-    let deps_max_ts    = max_timestamp t all_deps_as_list in
-    if rule_changed ||
-       match deps_max_ts, targets_min_ts with
-       | _, { missing_files = true; _ } ->
-         (* Missing targets -> rebuild *)
-         true
-       | _, { missing_files = false; limit = None } ->
-         (* CR-someday jdimino: no target, this should be a user error *)
-         true
-       | { missing_files = true; _ }, _ ->
-         Sexp.code_error
-           "Dependencies missing after waiting for them"
-           [ "all_deps", Sexp.To_sexp.list Path.sexp_of_t all_deps_as_list ]
-       | { limit = None; missing_files = false },
-         { missing_files = false; _ } ->
-         (* No dependencies, no need to do anything if the rule hasn't changed and targets
-            are here. *)
-         false
-       | { limit = Some deps_max; missing_files = false },
-         { limit = Some targets_min; missing_files = false } ->
-         targets_min < deps_max
-    then (
+    let targets_missing =
+      List.exists targets_as_list ~f:(fun fn ->
+        match Unix.lstat (Path.to_string fn) with
+        | exception _ -> true
+        | (_ : Unix.stats) -> false)
+    in
+    if deps_or_rule_changed || targets_missing then (
       (* Do not remove files that are just updated, otherwise this would break incremental
          compilation *)
       let targets_to_remove =
@@ -557,7 +504,7 @@ let compile_rule t ~all_targets_by_dir ?(copy_source=false) pre_rule =
       Option.iter sandbox_dir ~f:Path.rm_rf;
       (* All went well, these targets are no longer pending *)
       pending_targets := Pset.diff !pending_targets targets_to_remove;
-      refresh_targets_timestamps_after_rule_execution t targets_as_list
+      clear_targets_digests_after_rule_execution targets_as_list
     ) else
       return ()
   in
@@ -606,6 +553,7 @@ module Trace = struct
   let file = "_build/.db"
 
   let dump (trace : t) =
+    Utils.Cached_digest.dump ();
     let sexp =
       Sexp.List (
         Hashtbl.fold trace ~init:Pmap.empty ~f:(fun ~key ~data acc ->
@@ -618,6 +566,7 @@ module Trace = struct
       Io.write_file file (Sexp.to_string sexp)
 
   let load () =
+    Utils.Cached_digest.load ();
     let trace = Hashtbl.create 1024 in
     if Sys.file_exists file then begin
       let sexp = Sexp_lexer.Load.single file in
@@ -676,7 +625,6 @@ let create ~contexts ~file_tree ~rules =
     { contexts
     ; files      = Hashtbl.create 1024
     ; trace      = Trace.load ()
-    ; timestamps = Hashtbl.create 1024
     ; local_mkdirs = Path.Local.Set.empty
     } in
   List.iter rules ~f:(compile_rule t ~all_targets_by_dir ~copy_source:false);

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -253,7 +253,7 @@ module Gen(P : Params) = struct
                 main_module_name m.name
                 m.name (Module.real_unit_name m))
             |> String.concat ~sep:"\n")
-         >>> Build.update_file_dyn (Path.relative dir m.impl.name)));
+         >>> Build.write_file_dyn (Path.relative dir m.impl.name)));
 
     let requires, real_requires =
       SC.Libs.requires sctx ~dir ~dep_kind ~item:lib.name
@@ -838,7 +838,7 @@ Add it to your jbuild file to remove this warning.
            Format.pp_print_flush ppf ();
            Buffer.contents buf)
          >>>
-         Build.update_file_dyn meta_path);
+         Build.write_file_dyn meta_path);
 
       if has_meta || has_meta_tmpl then
         Some pkg.name
@@ -970,7 +970,7 @@ Add it to your jbuild file to remove this warning.
        >>^ (fun () ->
          Install.gen_install_file entries)
        >>>
-       Build.update_file_dyn fn)
+       Build.write_file_dyn fn)
 
   let () =
     let entries_per_package =

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -36,7 +36,7 @@ let dot_merlin sctx ~dir ({ requires; flags; _ } as t) =
     SC.add_rule sctx
       (Build.path path
        >>>
-       Build.update_file (Path.relative dir ".merlin-exists") "");
+       Build.write_file (Path.relative dir ".merlin-exists") "");
     SC.add_rule sctx (
       requires &&& flags
       >>^ (fun (libs, flags) ->
@@ -77,7 +77,7 @@ let dot_merlin sctx ~dir ({ requires; flags; _ } as t) =
         |> List.map ~f:(Printf.sprintf "%s\n")
         |> String.concat ~sep:"")
       >>>
-      Build.update_file_dyn path
+      Build.write_file_dyn path
     )
   | _ ->
     ()

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -89,7 +89,7 @@ let lib_index sctx ~odoc ~dir ~(lib : Library.t) ~lib_public_name ~doc_dir ~modu
               lib_public_name
               (String_map.keys modules |> String.concat ~sep:" "))))
      >>>
-     Build.update_file_dyn generated_index_mld);
+     Build.write_file_dyn generated_index_mld);
   let html_file =
     doc_dir ++ lib_public_name ++ "index.html"
   in

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -152,6 +152,7 @@ module type Combinators = sig
   val float      : float                     t
   val bool       : bool                      t
   val pair       : 'a t -> 'b t -> ('a * 'b) t
+  val triple     : 'a t -> 'b t -> 'c t -> ('a * 'b * 'c) t
   val list       : 'a t -> 'a list           t
   val array      : 'a t -> 'a array          t
   val option     : 'a t -> 'a option         t
@@ -168,6 +169,7 @@ module To_sexp = struct
   let float f = Atom (string_of_float f)
   let bool b = Atom (string_of_bool b)
   let pair fa fb (a, b) = List [fa a; fb b]
+  let triple fa fb fc (a, b, c) = List [fa a; fb b; fc c]
   let list f l = List (List.map l ~f)
   let array f a = list f (Array.to_list a)
   let option f = function
@@ -227,6 +229,10 @@ module Of_sexp = struct
   let pair fa fb = function
     | List (_, [a; b]) -> (fa a, fb b)
     | sexp -> of_sexp_error sexp "S-expression of the form (_ _) expected"
+
+  let triple fa fb fc = function
+    | List (_, [a; b; c]) -> (fa a, fb b, fc c)
+    | sexp -> of_sexp_error sexp "S-expression of the form (_ _ _) expected"
 
   let list f = function
     | Atom _ as sexp -> of_sexp_error sexp "List expected"

--- a/src/sexp.mli
+++ b/src/sexp.mli
@@ -41,6 +41,7 @@ module type Combinators = sig
   val float      : float                     t
   val bool       : bool                      t
   val pair       : 'a t -> 'b t -> ('a * 'b) t
+  val triple     : 'a t -> 'b t -> 'c t -> ('a * 'b * 'c) t
   val list       : 'a t -> 'a list           t
   val array      : 'a t -> 'a array          t
   val option     : 'a t -> 'a option         t

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -135,3 +135,80 @@ let obj_name_of_basename fn =
   match String.index fn '.' with
   | None -> fn
   | Some i -> String.sub fn ~pos:0 ~len:i
+
+module Cached_digest = struct
+  type file =
+    { mutable digest            : Digest.t
+    ; mutable timestamp         : float
+    ; mutable timestamp_checked : bool
+    }
+
+  let cache = Hashtbl.create 1024
+
+  let file fn =
+    match Hashtbl.find cache fn with
+    | Some x ->
+      if x.timestamp_checked then
+        x.digest
+      else begin
+        let mtime = (Unix.stat (Path.to_string fn)).st_mtime in
+        if mtime <> x.timestamp then begin
+          let digest = Digest.file (Path.to_string fn) in
+          x.digest    <- digest;
+          x.timestamp <- mtime;
+        end;
+        x.timestamp_checked <- true;
+        x.digest
+      end
+    | None ->
+      let digest = Digest.file (Path.to_string fn) in
+      Hashtbl.add cache ~key:fn
+        ~data:{ digest
+              ; timestamp = (Unix.stat (Path.to_string fn)).st_mtime
+              ; timestamp_checked = true
+              };
+      digest
+
+  let remove fn =
+    match Hashtbl.find cache fn with
+    | None -> ()
+    | Some file -> file.timestamp_checked <- false
+
+  let db_file = "_build/.digest-db"
+
+  let dump () =
+    let module Pmap = Path.Map in
+    let sexp =
+      Sexp.List (
+        Hashtbl.fold cache ~init:Pmap.empty ~f:(fun ~key ~data acc ->
+          Pmap.add acc ~key ~data)
+        |> Path.Map.bindings
+        |> List.map ~f:(fun (path, file) ->
+          Sexp.List [ Atom (Path.to_string path)
+                    ; Atom (Digest.to_hex file.digest)
+                    ; Atom (Int64.to_string (Int64.bits_of_float file.timestamp))
+                    ]))
+    in
+    if Sys.file_exists "_build" then
+      Io.write_file db_file (Sexp.to_string sexp)
+
+  let load () =
+    if Sys.file_exists db_file then begin
+      let sexp = Sexp_lexer.Load.single db_file in
+      let bindings =
+        let open Sexp.Of_sexp in
+        list
+          (triple
+             Path.t
+             (fun s -> Digest.from_hex (string s))
+             (fun s -> Int64.float_of_bits (Int64.of_string (string s)))
+          ) sexp
+      in
+      List.iter bindings ~f:(fun (path, digest, timestamp) ->
+        Hashtbl.add cache ~key:path
+          ~data:{ digest
+                ; timestamp
+                ; timestamp_checked = false
+                });
+    end
+end

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -43,3 +43,16 @@ val find_deps   : dir:Path.t -> 'a String_map.t -> string -> 'a
     - [obj_name_of_basename "toto.pp.ml" = "toto"]
 *)
 val obj_name_of_basename : string -> string
+
+(** Digest files with caching *)
+module Cached_digest : sig
+  (** Digest the contents of the following file *)
+  val file : Path.t -> Digest.t
+
+  (** Clear the following digest from the cache *)
+  val remove : Path.t -> unit
+
+  (** Dump/load the cache to/from the disk *)
+  val dump : unit -> unit
+  val load : unit -> unit
+end

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -29,7 +29,7 @@ let add_module_rules sctx ~dir lib_requires =
       pp_ml fmt include_paths;
       Format.pp_print_flush fmt ();
       Buffer.contents b)
-    >>> Build.update_file_dyn path in
+    >>> Build.write_file_dyn path in
   Super_context.add_rule sctx utop_ml
 
 let utop_of_libs (libs : Library.t list) =


### PR DESCRIPTION
As discussed in #158.

The implementation is rather simple and simply use `Digest.file`. The table `Path.t -> Digest.t` database is cached to disk and we use timestamps to avoid recomputing digests.

I tried this to build 99 Jane Street packages at once. Without caching the database to disk, null builds go from ~1.9s to ~10s. We'll typically get the same overhead for builds from scratch whether or not we cache the database . Building the 99 packages from scratch with `-j16`takes ~1.30s with master. So I guess it's not too bad.

After caching the database to disk, null builds take ~2.5s. We could improve this a bit by doing something clever for symlinks. We could also improve this by digesting files in a separate thread, but this will make the scheduler a lot more complicated.

This still needs a bit more testing. I was getting a few crashes during development.