### PR TITLE
Disable warning 31 for utop

### DIFF
--- a/src/utop.ml
+++ b/src/utop.ml
@@ -36,7 +36,10 @@ let utop_of_libs (libs : Library.t list) =
   { Executables.names = [exe_name]
   ; link_executables = true
   ; link_flags = Ordered_set_lang.Unexpanded.t (
-      Sexp.add_loc ~loc:Loc.none (List [Atom "-linkall"])
+      Sexp.add_loc ~loc:Loc.none
+        (List [ Atom "-linkall"
+              ; Atom "-w"
+              ; Atom "-31" ])
     )
   ; modes = Mode.Dict.Set.of_list [Mode.Byte]
   ; buildable =

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -38,7 +38,7 @@ let utop_of_libs (libs : Library.t list) =
   ; link_flags = Ordered_set_lang.Unexpanded.t (
       Sexp.add_loc ~loc:Loc.none
         (List [ Atom "-linkall"
-              ; Atom "-w"
+              ; Atom "-warn-error"
               ; Atom "-31" ])
     )
   ; modes = Mode.Dict.Set.of_list [Mode.Byte]


### PR DESCRIPTION
This allows jbuilder to create toplevels with conflicting module names. Such as
ExtLib's and Camomiles' UChar for example.

cc @jvillard