### PR TITLE
Allow bootstrap.ml to be compiled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ boot.ml
 *.corrected
 *.swp
 *.swo
+bootstrap.cmi
+bootstrap.cmo
+bootstrap.exe

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ all-supported-ocaml-versions:
 
 clean:
 	$(BIN) clean
-	rm -f ./boot.exe
+	rm -f ./boot.exe $(wildcard ./bootstrap.cmi ./bootstrap.cmo ./bootstrap.exe)
 
 doc:
 	cd doc && sphinx-build . _build

--- a/bootstrap.ml
+++ b/bootstrap.ml
@@ -1,4 +1,4 @@
-#warnings "-40";;
+[@@@ocaml.warning "-40"]
 
 module Array = ArrayLabels
 module List  = ListLabels


### PR DESCRIPTION
As it happens, bootstrap.ml doesn't trigger warning 40, but putting it as an attribute has the benefit of allowing bootstrap.ml to be compiled before being run.