### PR TITLE
Get rid of the deprecated-ppx-method sub-package

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,9 @@
   to add a field `(fallback)` to custom rules to keep the current
   behavior (#218)
 
+- Get rid of the `deprecated-ppx-method` findlib package for ppx
+  rewriters (#222, fixes #163)
+
 1.0+beta11 (21/07/2017)
 -----------------------
 


### PR DESCRIPTION
This PR simplifies the `META` files generated by jbuilder for ppx rewriters by dropping the `deprecated-ppx-method` sub-package. The fields it contains are inlined in the parent package.

We use to generate something like this:

```
requires(-ppx_driver) = "ppx_sexp_conv.deprecated-ppx-method"
package "deprecated-ppx-method" (
  version = "v0.9.0"
  description = "glue package for the deprecated method of using ppx"
  requires = "bigarray sexplib sexplib.0 unix"
  requires(-ppx_driver,-custom_ppx) += "ppx_deriving"
  ppxopt(-ppx_driver,-custom_ppx) = "ppx_deriving,package:ppx_sexp_conv"
)
```

now we generate:

```
requires(-ppx_driver) = "bigarray sexplib sexplib.0 unix"
requires(-ppx_driver,-custom_ppx) += "ppx_deriving"
ppxopt(-ppx_driver,-custom_ppx) = "ppx_deriving,package:ppx_sexp_conv"
```

I believe the new META files behave in the same way as the old ones.

Fixes #163 