### PR TITLE
Add a toplevel html index to the docs

### DIFF
--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -726,6 +726,7 @@ Add it to your jbuild file to remove this warning.
   let () =
     SC.add_rules sctx (Js_of_ocaml_rules.setup_separate_compilation_rules sctx)
   let () = Odoc.setup_css_rule sctx
+  let () = Odoc.setup_toplevel_index_rule sctx
 
   (* +-----------------------------------------------------------------+
      | META                                                            |

--- a/src/odoc.mli
+++ b/src/odoc.mli
@@ -13,3 +13,5 @@ val setup_library_rules
   -> unit
 
 val setup_css_rule : Super_context.t -> unit
+
+val setup_toplevel_index_rule: Super_context.t -> unit


### PR DESCRIPTION
See http://mirage.github.io/ocaml-git/index.html for an example of what is generated. It's really minimal at the moment but that's better than nothing.