### PR TITLE
Improve error handling for (:include )

### DIFF
--- a/src/ordered_set_lang.ml
+++ b/src/ordered_set_lang.ml
@@ -82,9 +82,12 @@ module Unexpanded = struct
       let open Ast in
       match t with
       | Element s -> Element s
-      | Special (l, s) -> Special (l, s)
       | Union [Special (_, "include"); Element fn] ->
           Include (Sexp.Of_sexp.string fn)
+      | Union [Special (loc, "include"); _]
+      | Special (loc, "include") ->
+          Loc.fail loc "(:include expects a single element (do you need to quote the filename?)"
+      | Special (l, s) -> Special (l, s)
       | Union l ->
           Union (List.map l ~f:map)
       | Diff (l, r) ->


### PR DESCRIPTION
The form `(:include $(SCOPE_ROOT)\foo)` requires quoting, but the error message was cryptic ("Error: undefined symbol include").

Related to #232 - see comment in https://github.com/janestreet/jbuilder/pull/153#issuecomment-324286383