### PR TITLE
Fix native code incremental compilation

### DIFF
--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -450,11 +450,18 @@ module Gen(P : Params) = struct
              ~mode
              [String.capitalize_ascii name]))
     in
-    let objs (_, cm) =
+    let objs (libs, cm) =
       if mode = Mode.Byte then
         []
       else
-        List.map ~f:(Path.change_extension ~ext:ctx.ext_obj) cm
+        let libs =
+          let f = function
+          | Lib.Internal (dir, lib) -> Some (Path.relative dir (lib.name ^ ctx.ext_lib))
+          | External _ -> None
+          in
+          List.filter_map ~f libs
+        in
+        libs @ List.map ~f:(Path.change_extension ~ext:ctx.ext_obj) cm
     in
     SC.add_rule sctx
       ((libs_and_cm >>> Build.dyn_paths (Build.arr objs))

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -384,6 +384,8 @@ module Gen(P : Params) = struct
         let src = lib_archive lib ~dir ~ext:(Mode.compiled_lib_ext Native) in
         let dst = lib_archive lib ~dir ~ext:".cmxs" in
         let build =
+          Build.dyn_paths (Build.arr (fun () -> [lib_archive lib ~dir ~ext:ctx.ext_lib]))
+          >>>
           Ocaml_flags.get flags Native
           >>>
           Build.run ~context:ctx

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -440,8 +440,14 @@ module Gen(P : Params) = struct
              ~mode
              [String.capitalize_ascii name]))
     in
+    let objs (_, cm) =
+      if mode = Mode.Byte then
+        []
+      else
+        List.map ~f:(Path.change_extension ~ext:ctx.ext_obj) cm
+    in
     SC.add_rule sctx
-      (libs_and_cm
+      ((libs_and_cm >>> Build.dyn_paths (Build.arr objs))
        &&&
        Build.fanout
        (Ocaml_flags.get flags mode)

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -86,6 +86,12 @@ module Gen(P : Params) = struct
         else
           fun x -> x
       in
+      let objs (cm, _, _, _) =
+        if mode = Mode.Byte then
+          []
+        else
+          List.map ~f:(Path.change_extension ~ext:ctx.ext_obj) cm
+      in
       SC.add_rule sctx
         (Build.fanout4
            (dep_graph >>>
@@ -99,6 +105,8 @@ module Gen(P : Params) = struct
            (SC.expand_and_eval_set sctx ~scope ~dir lib.c_library_flags ~standard:[])
            (Ocaml_flags.get flags mode)
            (SC.expand_and_eval_set sctx ~scope ~dir lib.library_flags ~standard:[])
+         >>>
+         Build.dyn_paths (Build.arr objs)
          >>>
          Build.run ~context:ctx (Dep compiler)
            ~extra_targets:(

--- a/src/path.ml
+++ b/src/path.ml
@@ -411,3 +411,7 @@ let rm_rf =
     match Unix.lstat fn with
     | exception Unix.Unix_error(ENOENT, _, _) -> ()
     | _ -> loop fn
+
+let change_extension ~ext t =
+  let t = try Filename.chop_extension t with Not_found -> t in
+  t ^ ext

--- a/src/path.mli
+++ b/src/path.mli
@@ -101,3 +101,6 @@ val rmdir : t -> unit
 val unlink : t -> unit
 val unlink_no_err : t -> unit
 val rm_rf : t -> unit
+
+(** Changes the extension of the filename (or adds an extension if there was none) *)
+val change_extension : ext:string -> t -> t


### PR DESCRIPTION
Alter `build_exe` so that the executable depends on the object files in native mode, as well as the .cmx files.

It may be necessary to extend this to .cmxa?