### PR TITLE
Run tests in CI

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -24,13 +24,19 @@ case "$TARGET" in
     echo -en "travis_fold:end:ocaml\r"
     if [ $WITH_OPAM -eq 1 ] ; then
       echo -en "travis_fold:start:opam.init\r"
+      if [ "$TRAVIS_OS_NAME" = "osx" ] ; then
+        brew install aspcud
+        PREFIX=/Users/travis
+      else
+        PREFIX=/home/travis
+      fi
       if [ ! -e ~/ocaml/bin/opam -o ! -e ~/.opam/lock -o "$OPAM_RESET" = "1" ] ; then
         mkdir ~/ocaml/src
         cd ~/ocaml/src
         wget https://github.com/ocaml/opam/releases/download/1.2.2/opam-full-1.2.2.tar.gz
         tar -xzf opam-full-1.2.2.tar.gz
         cd opam-full-1.2.2
-        ./configure --prefix=/home/travis/ocaml
+        ./configure --prefix=$PREFIX/ocaml
         make lib-ext
         make all
         make install

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -17,19 +17,28 @@ case "$TARGET" in
       ./configure -prefix ~/ocaml
       make world.opt
       make install
-      cd ..
+      cd ../..
       rm -rf src
       echo "$OCAML_VERSION.$OCAML_RELEASE" > ~/ocaml/cached-version
     fi
     echo -en "travis_fold:end:ocaml\r"
     if [ $WITH_OPAM -eq 1 ] ; then
       echo -en "travis_fold:start:opam.init\r"
-      sudo add-apt-repository --yes ppa:avsm/ocaml42+opam12
-      sudo apt-get update -qq
-      sudo apt-get -yq --no-install-suggests --no-install-recommends --force-yes install opam
-      if [ ! -e ~/.opam/lock -o "$OPAM_RESET" = "1" ] ; then
+      if [ ! -e ~/ocaml/bin/opam -o ! -e ~/.opam/lock -o "$OPAM_RESET" = "1" ] ; then
+        mkdir ~/ocaml/src
+        cd ~/ocaml/src
+        wget https://github.com/ocaml/opam/releases/download/1.2.2/opam-full-1.2.2.tar.gz
+        tar -xzf opam-full-1.2.2.tar.gz
+        cd opam-full-1.2.2
+        ./configure --prefix=/home/travis/ocaml
+        make lib-ext
+        make all
+        make install
+        cd ../..
+        rm -rf src
         rm -rf ~/.opam
         opam init --yes
+        eval $(opam config env)
         opam install menhir ocaml-migrate-parsetree js_of_ocaml-ppx --yes
         opam remove jbuilder `opam list --depends-on jbuilder --installed --short` --yes
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,7 @@ matrix:
   - os: linux
     env: OCAML_VERSION=4.05 OCAML_RELEASE=0 WITH_OPAM=1
     stage: Test
-    sudo: required
+    addons:
+      apt:
+        packages:
+        - aspcud

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,25 +14,13 @@ matrix:
   - os: linux
     env: OCAML_VERSION=4.02 OCAML_RELEASE=3 WITH_OPAM=0
     stage: Build
-  - os: osx
-    env: OCAML_VERSION=4.02 OCAML_RELEASE=3 WITH_OPAM=0
-    stage: Build
   - os: linux
-    env: OCAML_VERSION=4.03 OCAML_RELEASE=0 WITH_OPAM=0
-    stage: Build
-  - os: osx
     env: OCAML_VERSION=4.03 OCAML_RELEASE=0 WITH_OPAM=0
     stage: Build
   - os: linux
     env: OCAML_VERSION=4.04 OCAML_RELEASE=2 WITH_OPAM=0
     stage: Build
-  - os: osx
-    env: OCAML_VERSION=4.04 OCAML_RELEASE=2 WITH_OPAM=0
-    stage: Build
   - os: linux
-    env: OCAML_VERSION=4.05 OCAML_RELEASE=0 WITH_OPAM=0
-    stage: Build
-  - os: osx
     env: OCAML_VERSION=4.05 OCAML_RELEASE=0 WITH_OPAM=0
     stage: Build
   - os: linux
@@ -43,5 +31,17 @@ matrix:
         packages:
         - aspcud
   - os: osx
+    env: OCAML_VERSION=4.02 OCAML_RELEASE=3 WITH_OPAM=0
+    stage: Build_macOS
+  - os: osx
+    env: OCAML_VERSION=4.03 OCAML_RELEASE=0 WITH_OPAM=0
+    stage: Build_macOS
+  - os: osx
+    env: OCAML_VERSION=4.04 OCAML_RELEASE=2 WITH_OPAM=0
+    stage: Build_macOS
+  - os: osx
+    env: OCAML_VERSION=4.05 OCAML_RELEASE=0 WITH_OPAM=0
+    stage: Build_macOS
+  - os: osx
     env: OCAML_VERSION=4.05 OCAML_RELEASE=0 WITH_OPAM=1
-    stage: Test
+    stage: Test_macOS

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,6 @@ matrix:
       apt:
         packages:
         - aspcud
+  - os: osx
+    env: OCAML_VERSION=4.05 OCAML_RELEASE=0 WITH_OPAM=1
+    stage: Test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,38 @@ sudo: false
 cache:
   directories:
   - $HOME/ocaml
+  - $HOME/.opam
 
 install: bash -ex .travis-ci.sh prepare
 script: bash -ex .travis-ci.sh build
-env:
-  global:
-  - PACKAGE=jbuilder
-  matrix:
-  - OCAML_VERSION=4.02 OCAML_RELEASE=3
-  - OCAML_VERSION=4.03 OCAML_RELEASE=0
-  - OCAML_VERSION=4.04 OCAML_RELEASE=2
-  - OCAML_VERSION=4.05 OCAML_RELEASE=0
-os:
-  - linux
-  - osx
+
+matrix:
+  include:
+  - os: linux
+    env: OCAML_VERSION=4.02 OCAML_RELEASE=3 WITH_OPAM=0
+    stage: Build
+  - os: osx
+    env: OCAML_VERSION=4.02 OCAML_RELEASE=3 WITH_OPAM=0
+    stage: Build
+  - os: linux
+    env: OCAML_VERSION=4.03 OCAML_RELEASE=0 WITH_OPAM=0
+    stage: Build
+  - os: osx
+    env: OCAML_VERSION=4.03 OCAML_RELEASE=0 WITH_OPAM=0
+    stage: Build
+  - os: linux
+    env: OCAML_VERSION=4.04 OCAML_RELEASE=2 WITH_OPAM=0
+    stage: Build
+  - os: osx
+    env: OCAML_VERSION=4.04 OCAML_RELEASE=2 WITH_OPAM=0
+    stage: Build
+  - os: linux
+    env: OCAML_VERSION=4.05 OCAML_RELEASE=0 WITH_OPAM=0
+    stage: Build
+  - os: osx
+    env: OCAML_VERSION=4.05 OCAML_RELEASE=0 WITH_OPAM=0
+    stage: Build
+  - os: linux
+    env: OCAML_VERSION=4.05 OCAML_RELEASE=0 WITH_OPAM=1
+    stage: Test
+    sudo: required


### PR DESCRIPTION
This PR also includes a couple of cosmetic changes to the Travis scripts.

The main change is to add a second build stage which runs the latest OCaml and opam in order to allow the testsuite to be run. So the testsuite is run only if the main OS/OCaml matrix passes.

Somebody with more patience than me with useless formats like YAML may be able to compress the build matrix; I got bored with uploading samples and wasn't sufficiently interested to download the Travis ruby scripts locally to try testing it...