### PR TITLE
Add dynlink builtin META package

### DIFF
--- a/src/meta.ml
+++ b/src/meta.ml
@@ -192,6 +192,7 @@ let builtins =
   let str = simple "str" [] ~dir:"+" in
   let unix = simple "unix" [] ~dir:"+" in
   let bigarray = simple "bigarray" ["unix"] ~dir:"+" in
+  let dynlink = simple "dynlink" [] ~dir:"+" in
   let threads =
     { name = "threads"
     ; entries =
@@ -216,7 +217,7 @@ let builtins =
         ]
     }
   in
-  List.map [ compiler_libs; str; unix; bigarray; threads; num ] ~f:(fun t -> t.name, t)
+  List.map [ compiler_libs; str; unix; bigarray; threads; num; dynlink ] ~f:(fun t -> t.name, t)
   |> String_map.of_alist_exn
 
 let string_of_action = function


### PR DESCRIPTION
There's more to do here for generating these dependent on compiler version (dynlink should be probed, for example, and num no longer exists in 4.06)