### PR TITLE
Modular Menhir in non-root directory

### DIFF
--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -831,10 +831,10 @@ module Menhir = struct
              (S.virt_var __POS__ "ROOT",
               Run (S.virt_text __POS__ "menhir",
                    [ S.virt_text __POS__ "--base"
-                   ; S.virt_text __POS__ merge_into
+                   ; S.virt_var __POS__ ("path-no-dep:" ^ merge_into)
                    ]
                    @ t.flags
-                   @ (List.map ~f:mly t.modules))
+                   @ [S.virt_var __POS__ "!^"])
              )
        ; fallback = Not_possible
        ; loc

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -515,6 +515,7 @@ module Action = struct
         match String.lsplit2 var ~on:':' with
         | Some ("exe"     , s) -> static_dep_exp acc (Path.relative dir s)
         | Some ("path"    , s) -> static_dep_exp acc (Path.relative dir s)
+        | Some ("path-no-dep", s) -> Some (path_exp @@ Path.relative dir s)
         | Some ("bin"     , s) -> begin
             match A.binary (artifacts sctx) s with
             | Ok path -> static_dep_exp acc path

--- a/test/blackbox-tests/jbuild
+++ b/test/blackbox-tests/jbuild
@@ -52,6 +52,13 @@
 
 (alias
  ((name runtest)
+  (deps ((files_recursively_in test-cases/menhir2)))
+  (action
+   (chdir test-cases/menhir2
+    (setenv JBUILDER ${bin:jbuilder} (run ${exe:cram.exe} run.t))))))
+
+(alias
+ ((name runtest)
   (deps ((files_recursively_in test-cases/github25)))
   (action
    (chdir test-cases/github25/root

--- a/test/blackbox-tests/test-cases/menhir2/run.t
+++ b/test/blackbox-tests/test-cases/menhir2/run.t
@@ -1,0 +1,15 @@
+  $ $JBUILDER build -j1 src/test.exe --root . --debug-dependency-path
+      ocamllex src/lexer.ml
+        menhir src/parser.{ml,mli}
+        menhir src/tokens.{ml,mli}
+      ocamldep src/test.depends.ocamldep-output
+      ocamldep src/test.dependsi.ocamldep-output
+        ocamlc src/tokens.{cmi,cmti}
+      ocamlopt src/tokens.{cmx,o}
+        ocamlc src/lexer.{cmi,cmo,cmt}
+        ocamlc src/parser.{cmi,cmti}
+      ocamlopt src/lexer.{cmx,o}
+      ocamlopt src/parser.{cmx,o}
+        ocamlc src/test.{cmi,cmo,cmt}
+      ocamlopt src/test.{cmx,o}
+      ocamlopt src/test.exe

--- a/test/blackbox-tests/test-cases/menhir2/src/jbuild
+++ b/test/blackbox-tests/test-cases/menhir2/src/jbuild
@@ -1,0 +1,15 @@
+(jbuild_version 1)
+
+(ocamllex (lexer))
+
+(menhir
+ ((flags (--only-tokens))
+  (modules (tokens))))
+
+(menhir
+ ((merge_into parser)
+  (flags (--external-tokens Tokens))
+  (modules (tokens parser))))
+
+(executables
+ ((names (test))))

--- a/test/blackbox-tests/test-cases/menhir2/src/lexer.mll
+++ b/test/blackbox-tests/test-cases/menhir2/src/lexer.mll
@@ -1,0 +1,7 @@
+{
+open Tokens
+}
+
+rule lex = parse
+  | 'c' { TOKEN 'c' }
+  | eof { EOF }

--- a/test/blackbox-tests/test-cases/menhir2/src/parser.mly
+++ b/test/blackbox-tests/test-cases/menhir2/src/parser.mly
@@ -1,0 +1,7 @@
+%start <char list> main
+
+%%
+
+main:
+| c = TOKEN EOF { [c] }
+| c = TOKEN xs = main  { c :: xs }

--- a/test/blackbox-tests/test-cases/menhir2/src/test.ml
+++ b/test/blackbox-tests/test-cases/menhir2/src/test.ml
@@ -1,0 +1,3 @@
+let () =
+  let lex = Lexing.from_string "yo" in
+  ignore (Parser.main Lexer.lex lex);

--- a/test/blackbox-tests/test-cases/menhir2/src/tokens.mly
+++ b/test/blackbox-tests/test-cases/menhir2/src/tokens.mly
@@ -1,0 +1,5 @@
+%token <char> TOKEN
+%token EOF
+
+%%
+


### PR DESCRIPTION
I was recently trying to use jbuilder to build a modular Menhir parser, it worked
well until I decided to move the sources into a sub-directory.

I wrote a black-box test showing how it breaks. I also hacked together some
changes to resolve the target parser and dependencies correctly.

However, there might be a better/easier way to do this, improvements are more than
welcome. The `path-no-dep` is of course a horrible work-in-progress name, any
suggestions for a better one?