### PR TITLE
Ensure Clflags.workspace_root is always absolute

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -35,9 +35,9 @@ let set_common c ~targets =
   Clflags.dev_mode := c.dev_mode;
   Clflags.verbose := c.verbose;
   Clflags.capture_outputs := c.capture_outputs;
-  Clflags.workspace_root := c.root;
   if c.root <> Filename.current_dir_name then
     Sys.chdir c.root;
+  Clflags.workspace_root := Sys.getcwd ();
   Clflags.external_lib_deps_hint :=
     List.concat
       [ ["jbuilder"; "external-lib-deps"; "--missing"]


### PR DESCRIPTION
While investigating the Travis failure in #239, I discovered a bug in https://github.com/janestreet/jbuilder/commit/3fb191503385ebb12c4c37a710d84753fa1a7b5e. The new `Path.to_absolute` function asserts that Clflags.workspace_root is absolute, but this isn't true *especially* if `jbuilder build` was called with `-p` (which implies `--root=.`). The simple fix is to set `workspace_root` to the cwd immediately after chdir call.

This can be seen by pinning jbuilder and trying to install cppo 1.6.0 in Opam (it won't be seen with cppo master because it no longer uses OCaml syntax)
