### PR TITLE
Sort out recursive/non-recursive aliases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,16 @@
+next
+----
+
+- Change the semantic of aliases: there are no longer aliases that are
+  recursive such as `install` or `runtest`. All aliases are
+  non-recursive. However, when requesting an alias from the command
+  line, this request the construction of the alias in the specified
+  directory and all its children recursively. This allows users to get
+  the same behavior as previous recursive aliases for their own
+  aliases, such as `example`. Inside jbuild files, one can use `(deps
+  (... (alias_rec xxx) ...))` to get the same behavior as on the
+  command line.
+
 1.0+beta14 (11/10/2017)
 -----------------------
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -390,9 +390,7 @@ let resolve_targets ~log common (setup : Main.setup) user_targets =
           if Path.is_root path then
             die "@@ on the command line must be followed by a valid alias name"
           else
-            let dir = Path.parent path in
-            let name = Path.basename path in
-            [Alias_rec (Alias.make ~dir name)]
+            [Alias_rec (Alias.of_path path)]
         else
           let path = Path.relative Path.root (prefix_target common s) in
           let can't_build path =

--- a/doc/jbuild.rst
+++ b/doc/jbuild.rst
@@ -843,6 +843,10 @@ syntax:
 - ``(file <filename>)`` or simply ``<filename>``: depend on this file
 - ``(alias <alias-name>)``: depend on the construction of this alias, for
   instance: ``(alias src/runtest)``
+- ``(alias_rec <alias-name>)``: depend on the construction of this
+  alias recursively in all children directories wherever it is
+  defined. For instance: ``(alias_rec src/runtest)`` might depend on
+  ``(alias src/runtest)``, ``(alias src/foo/bar/runtest)``, ...
 - ``(glob_files <glob>)``: depend on all files matched by ``<glob>``, see the
   :ref:`glob <glob>` for details
 - ``(files_recursively_in <dir>)``: depend on all files in the subtree with root

--- a/doc/terminology.rst
+++ b/doc/terminology.rst
@@ -43,11 +43,12 @@ Terminology
 -  **build context root**: the root of a build context named ``foo`` is
    ``<root>/_build/<foo>``
 
--  **alias**: an alias is a build target that doesn't produce any file
-   and has configurable dependencies. Alias are per-directory and some
-   are recursive; asking an alias to be built in a given directory will
-   trigger the construction of the alias in all children directories
-   recursively. The most interesting ones are:
+- **alias**: an alias is a build target that doesn't produce any file
+   and has configurable dependencies. Aliases are
+   per-directory. However, on the command line, asking for an alias to
+   be built in a given directory will trigger the construction of the
+   alias in all children directories recursively. Jbuilder defines the
+   following standard aliases:
 
    -  ``runtest`` which runs user defined tests
    -  ``install`` which depends on everything that should be installed

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -125,8 +125,9 @@ Aliases
 -------
 
 Targets starting with a ``@`` are interpreted as aliases. For instance
-``@src/runtest`` means the alias ``src/runtest``. If you want to refer
-to a target starting with a ``@``, simply write: ``./@foo``.
+``@src/runtest`` means the alias ``runtest`` in all descendant of
+``src`` where it is defined. If you want to refer to a target starting
+with a ``@``, simply write: ``./@foo``.
 
 Note that an alias not pointing to the ``_build`` directory always
 depends on all the corresponding aliases in build contexts.

--- a/src/alias.ml
+++ b/src/alias.ml
@@ -65,7 +65,7 @@ let dep_rec ~loc ~file_tree t =
           ~else_:(Build.arr (fun x -> x)))
     >>^ fun is_empty ->
     if is_empty && not (is_standard name) then
-      Loc.fail loc "This recursive alias is empty.\n\
+      Loc.fail loc "This alias is empty.\n\
                     Alias %S is not defined in %s or any of its descendants."
         name (Path.to_string_maybe_quoted path)
 

--- a/src/alias.mli
+++ b/src/alias.mli
@@ -2,6 +2,8 @@ type t
 
 val make : string -> dir:Path.t -> t
 
+val of_path : Path.t -> t
+
 (** The following always holds:
 
     {[

--- a/src/alias.mli
+++ b/src/alias.mli
@@ -48,10 +48,8 @@ end
 
 val add_deps : Store.t -> t -> Path.t list -> unit
 
-type tree = Node of Path.t * tree list
-
 val rules
   :  Store.t
   -> prefixes:Path.t list
-  -> tree:tree
+  -> file_tree:File_tree.t
   -> Build_interpret.Rule.t list

--- a/src/alias.mli
+++ b/src/alias.mli
@@ -54,8 +54,4 @@ end
 
 val add_deps : Store.t -> t -> Path.t list -> unit
 
-val rules
-  :  Store.t
-  -> prefixes:Path.t list
-  -> file_tree:File_tree.t
-  -> Build_interpret.Rule.t list
+val rules : Store.t -> Build_interpret.Rule.t list

--- a/src/alias.mli
+++ b/src/alias.mli
@@ -11,12 +11,18 @@ val make : string -> dir:Path.t -> t
 val name : t -> string
 val dir  : t -> Path.t
 
+val fully_qualified_name : t -> Path.t
+
 val default : dir:Path.t -> t
 val runtest : dir:Path.t -> t
 val install : dir:Path.t -> t
 val doc     : dir:Path.t -> t
 
 val dep : t -> ('a, 'a) Build.t
+
+(** Implements [(alias_rec ...)] in dependency specification and
+    [@alias] on the command line. *)
+val dep_rec : loc:Loc.t -> file_tree:File_tree.t -> t -> (unit, unit) Build.t
 
 (** File that represent the alias in the filesystem. It is a file under
     [_build/.aliases]. *)

--- a/src/alias.mli
+++ b/src/alias.mli
@@ -1,4 +1,8 @@
+open Import
+
 type t
+
+val pp : t Fmt.t
 
 val make : string -> dir:Path.t -> t
 
@@ -51,6 +55,9 @@ val name_of_file : Path.t -> string option
 
 module Store : sig
   type t
+
+  val pp : t Fmt.t
+
   val create : unit -> t
 end
 

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -603,14 +603,14 @@ let dump_trace t = Trace.dump t.trace
 
 let create ~contexts ~file_tree ~rules =
   let all_source_files =
-    File_tree.fold file_tree ~init:Pset.empty ~f:(fun dir acc ->
-      let path = File_tree.Dir.path dir in
-      Cont
-        (Pset.union acc
-           (File_tree.Dir.files dir
-            |> String_set.elements
-            |> List.map ~f:(Path.relative path)
-            |> Pset.of_list)))
+    File_tree.fold file_tree ~init:Pset.empty ~traverse_ignored_dirs:true
+      ~f:(fun dir acc ->
+        let path = File_tree.Dir.path dir in
+        Pset.union acc
+          (File_tree.Dir.files dir
+           |> String_set.elements
+           |> List.map ~f:(Path.relative path)
+           |> Pset.of_list))
   in
   let all_copy_targets =
     List.fold_left contexts ~init:Pset.empty ~f:(fun acc (ctx : Context.t) ->

--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -23,16 +23,28 @@ module Build_error : sig
 end
 
 (** Do the actual build *)
-val do_build     : t -> Path.t list -> (unit Future.t, Build_error.t) result
-val do_build_exn : t -> Path.t list -> unit Future.t
+val do_build
+  :  t
+  -> request:(unit, unit) Build.t
+  -> (unit Future.t, Build_error.t) result
+val do_build_exn
+  :  t
+  -> request:(unit, unit) Build.t
+  -> unit Future.t
 
-(** Return all the library dependencies (as written by the user) needed to build these
-    targets *)
-val all_lib_deps : t -> Path.t list -> Build.lib_deps Path.Map.t
+(** Return all the library dependencies (as written by the user)
+   needed to build this request *)
+val all_lib_deps
+  :  t
+  -> request:(unit, unit) Build.t
+  -> Build.lib_deps Path.Map.t
 
-(** Return all the library dependencies required to build these targets, by context
-    name *)
-val all_lib_deps_by_context : t -> Path.t list -> Build.lib_deps String_map.t
+(** Return all the library dependencies required to build this
+   request, by context name *)
+val all_lib_deps_by_context
+  :  t
+  -> request:(unit, unit) Build.t
+  -> Build.lib_deps String_map.t
 
 (** List of all buildable targets *)
 val all_targets : t -> Path.t list
@@ -58,9 +70,9 @@ end
     [recursive] is [true], return all the rules needed to build the
     given targets and their transitive dependencies. *)
 val build_rules
-  :  t
-  -> ?recursive:bool (* default false *)
-  -> Path.t list
+  :  ?recursive:bool (* default false *)
+  -> t
+  -> request:(unit, unit) Build.t
   -> Rule.t list Future.t
 
 val all_targets_ever_built

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -34,7 +34,7 @@ let ignore_file fn ~is_directory =
   (is_directory && (fn.[0] = '.' || fn.[0] = '_')) ||
   (fn.[0] = '.' && fn.[1] = '#')
 
-let load path =
+let load ?(extra_ignored_subtrees=Path.Set.empty) path =
   let rec walk path ~ignored : Dir.t =
     let files, sub_dirs =
       Path.readdir path
@@ -61,7 +61,11 @@ let load path =
     in
     let sub_dirs =
       List.map sub_dirs ~f:(fun (fn, path) ->
-        let ignored = ignored || String_set.mem fn ignored_sub_dirs in
+        let ignored =
+          ignored
+          || String_set.mem fn ignored_sub_dirs
+          || Path.Set.mem path extra_ignored_subtrees
+        in
         (fn, walk path ~ignored))
       |> String_map.of_alist_exn
     in

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -1,31 +1,25 @@
 open! Import
 
-type 'a fold_callback_result =
-  | Cont            of 'a
-  | Dont_recurse_in of String_set.t * 'a
-
 module Dir = struct
   type t =
     { path     : Path.t
     ; files    : String_set.t
     ; sub_dirs : t String_map.t
+    ; ignored  : bool
     }
 
   let path t = t.path
   let files t = t.files
   let sub_dirs t = t.sub_dirs
+  let ignored t = t.ignored
 
-  let rec fold t ~init ~f =
-    match f t init with
-    | Cont init ->
-      String_map.fold t.sub_dirs ~init ~f:(fun ~key:_ ~data:t acc ->
-        fold t ~init:acc ~f)
-    | Dont_recurse_in (forbidden, init) ->
-      String_map.fold t.sub_dirs ~init ~f:(fun ~key:sub_dir ~data:t acc ->
-        if String_set.mem sub_dir forbidden then
-          acc
-        else
-          fold t ~init:acc ~f)
+  let rec fold t ~traverse_ignored_dirs ~init:acc ~f =
+    if not traverse_ignored_dirs && t.ignored then
+      acc
+    else
+      let acc = f t acc in
+      String_map.fold t.sub_dirs ~init:acc ~f:(fun ~key:_ ~data:t acc ->
+        fold t ~traverse_ignored_dirs ~init:acc ~f)
 end
 
 type t =
@@ -41,37 +35,54 @@ let ignore_file fn ~is_directory =
   (fn.[0] = '.' && fn.[1] = '#')
 
 let load path =
-  let rec walk path : Dir.t =
+  let rec walk path ~ignored : Dir.t =
     let files, sub_dirs =
       Path.readdir path
       |> List.filter_map ~f:(fun fn ->
         let path = Path.relative path fn in
-        let is_directory = Path.exists path && Path.is_directory path in
+        let is_directory =
+          try Path.is_directory path with _ -> false
+        in
         if ignore_file fn ~is_directory then
           None
+        else if is_directory then
+          Some (Inr (fn, path))
         else
-          Some (fn, path, is_directory))
-      |> List.partition_map ~f:(fun (fn, path, is_directory)  ->
-          if is_directory then
-            Inr (fn, walk path)
-          else
-            Inl fn)
+          Some (Inl fn))
+      |> List.partition_map ~f:(fun x -> x)
+    in
+    let files = String_set.of_list files in
+    let ignored_sub_dirs =
+      if not ignored && String_set.mem "jbuild-ignore" files then
+        String_set.of_list
+          (Io.lines_of_file (Path.to_string (Path.relative path "jbuild-ignore")))
+      else
+        String_set.empty
+    in
+    let sub_dirs =
+      List.map sub_dirs ~f:(fun (fn, path) ->
+        let ignored = ignored || String_set.mem fn ignored_sub_dirs in
+        (fn, walk path ~ignored))
+      |> String_map.of_alist_exn
     in
     { path
-    ; files    = String_set.of_list files
-    ; sub_dirs = String_map.of_alist_exn sub_dirs
+    ; files
+    ; sub_dirs
+    ; ignored
     }
   in
-  let root = walk path in
+  let root = walk path ~ignored:false in
   let dirs =
-    Dir.fold root ~init:Path.Map.empty ~f:(fun dir acc ->
-      Cont (Path.Map.add acc ~key:dir.path ~data:dir))
+    Dir.fold root ~init:Path.Map.empty ~traverse_ignored_dirs:true
+      ~f:(fun dir acc ->
+        Path.Map.add acc ~key:dir.path ~data:dir)
   in
   { root
   ; dirs
   }
 
-let fold t ~init ~f = Dir.fold t.root ~init ~f
+let fold t ~traverse_ignored_dirs ~init ~f =
+  Dir.fold t.root ~traverse_ignored_dirs ~init ~f
 
 let find_dir t path =
   Path.Map.find path t.dirs
@@ -89,8 +100,8 @@ let files_recursively_in t ?(prefix_with=Path.root) path =
   match find_dir t path with
   | None -> Path.Set.empty
   | Some dir ->
-    Dir.fold dir ~init:Path.Set.empty ~f:(fun dir acc ->
-      let path = Path.append prefix_with (Dir.path dir) in
-      Cont
-        (String_set.fold (Dir.files dir) ~init:acc ~f:(fun fn acc ->
-           Path.Set.add (Path.relative path fn) acc)))
+    Dir.fold dir ~init:Path.Set.empty ~traverse_ignored_dirs:true
+      ~f:(fun dir acc ->
+        let path = Path.append prefix_with (Dir.path dir) in
+        String_set.fold (Dir.files dir) ~init:acc ~f:(fun fn acc ->
+          Path.Set.add (Path.relative path fn) acc))

--- a/src/file_tree.mli
+++ b/src/file_tree.mli
@@ -10,6 +10,13 @@ module Dir : sig
   (** Whether this directory is ignored by a [jbuild-ignore] file in
       one of its ancestor directories. *)
   val ignored : t -> bool
+
+  val fold
+    :  t
+    -> traverse_ignored_dirs:bool
+    -> init:'a
+    -> f:(t -> 'a -> 'a)
+    -> 'a
 end
 
 type t

--- a/src/file_tree.mli
+++ b/src/file_tree.mli
@@ -14,7 +14,7 @@ end
 
 type t
 
-val load : Path.t -> t
+val load : ?extra_ignored_subtrees:Path.Set.t -> Path.t -> t
 
 val fold
   :  t

--- a/src/file_tree.mli
+++ b/src/file_tree.mli
@@ -1,23 +1,27 @@
 open! Import
 
-
 module Dir : sig
   type t
 
   val path     : t -> Path.t
   val files    : t -> String_set.t
   val sub_dirs : t -> t String_map.t
+
+  (** Whether this directory is ignored by a [jbuild-ignore] file in
+      one of its ancestor directories. *)
+  val ignored : t -> bool
 end
 
 type t
 
 val load : Path.t -> t
 
-type 'a fold_callback_result =
-  | Cont            of 'a
-  | Dont_recurse_in of String_set.t * 'a
-
-val fold : t -> init:'a -> f:(Dir.t -> 'a -> 'a fold_callback_result) -> 'a
+val fold
+  :  t
+  -> traverse_ignored_dirs:bool
+  -> init:'a
+  -> f:(Dir.t -> 'a -> 'a)
+  -> 'a
 
 val root : t -> Dir.t
 

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -1151,6 +1151,6 @@ let gen ~contexts ?(filter_out_optional_stanzas_with_missing_deps=true)
   >>| fun l ->
   let rules, context_names_and_stanzas = List.split l in
   (Alias.rules aliases
-     ~prefixes:(Path.root :: List.map contexts ~f:(fun c -> c.Context.build_dir)) ~file_tree
+        ~prefixes:(Path.root :: List.map contexts ~f:(fun c -> c.Context.build_dir)) ~file_tree
    @ List.concat rules,
    String_map.of_alist_exn context_names_and_stanzas)

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -1150,7 +1150,5 @@ let gen ~contexts ?(filter_out_optional_stanzas_with_missing_deps=true)
   |> Future.all
   >>| fun l ->
   let rules, context_names_and_stanzas = List.split l in
-  (Alias.rules aliases
-        ~prefixes:(Path.root :: List.map contexts ~f:(fun c -> c.Context.build_dir)) ~file_tree
-   @ List.concat rules,
+  (Alias.rules aliases @ List.concat rules,
    String_map.of_alist_exn context_names_and_stanzas)

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -1104,7 +1104,7 @@ end
 let gen ~contexts ?(filter_out_optional_stanzas_with_missing_deps=true)
       ?only_packages conf =
   let open Future in
-  let { Jbuild_load. file_tree; tree; jbuilds; packages } = conf in
+  let { Jbuild_load. file_tree; jbuilds; packages } = conf in
   let aliases = Alias.Store.create () in
   let dirs_with_dot_opam_files =
     String_map.fold packages ~init:Path.Set.empty
@@ -1151,6 +1151,6 @@ let gen ~contexts ?(filter_out_optional_stanzas_with_missing_deps=true)
   >>| fun l ->
   let rules, context_names_and_stanzas = List.split l in
   (Alias.rules aliases
-     ~prefixes:(Path.root :: List.map contexts ~f:(fun c -> c.Context.build_dir)) ~tree
+     ~prefixes:(Path.root :: List.map contexts ~f:(fun c -> c.Context.build_dir)) ~file_tree
    @ List.concat rules,
    String_map.of_alist_exn context_names_and_stanzas)

--- a/src/import.ml
+++ b/src/import.ml
@@ -504,3 +504,7 @@ let open_out_gen = `Use_Io
 module No_io = struct
   module Io = struct end
 end
+
+module Fmt = struct
+  type 'a t = Format.formatter -> 'a -> unit
+end

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -200,6 +200,7 @@ module Dep_conf = struct
   type t =
     | File of String_with_vars.t
     | Alias of String_with_vars.t
+    | Alias_rec of String_with_vars.t
     | Glob_files of String_with_vars.t
     | Files_recursively_in of String_with_vars.t
 
@@ -211,6 +212,7 @@ module Dep_conf = struct
       sum
         [ cstr "file"                 (fun x -> File x)
         ; cstr "alias"                (fun x -> Alias x)
+        ; cstr "alias_rec"            (fun x -> Alias_rec x)
         ; cstr "glob_files"           (fun x -> Glob_files x)
         ; cstr "files_recursively_in" (fun x -> Files_recursively_in x)
         ]
@@ -226,6 +228,8 @@ module Dep_conf = struct
       List [Atom "file" ; String_with_vars.sexp_of_t t]
     | Alias t ->
       List [Atom "alias" ; String_with_vars.sexp_of_t t]
+    | Alias_rec t ->
+      List [Atom "alias_rec" ; String_with_vars.sexp_of_t t]
     | Glob_files t ->
       List [Atom "glob_files" ; String_with_vars.sexp_of_t t]
     | Files_recursively_in t ->

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -93,6 +93,7 @@ module Dep_conf : sig
   type t =
     | File of String_with_vars.t
     | Alias of String_with_vars.t
+    | Alias_rec of String_with_vars.t
     | Glob_files of String_with_vars.t
     | Files_recursively_in of String_with_vars.t
 

--- a/src/jbuild_load.ml
+++ b/src/jbuild_load.ml
@@ -166,39 +166,25 @@ let load ~dir ~scope =
 
 let load ?(extra_ignored_subtrees=Path.Set.empty) () =
   let ftree = File_tree.load Path.root in
-  let packages, ignored_subtrees =
-    File_tree.fold ftree ~init:([], extra_ignored_subtrees) ~f:(fun dir (pkgs, ignored) ->
+  let packages =
+    File_tree.fold ftree ~traverse_ignored_dirs:false ~init:[] ~f:(fun dir pkgs ->
       let path = File_tree.Dir.path dir in
       let files = File_tree.Dir.files dir in
-      let pkgs =
-        String_set.fold files ~init:pkgs ~f:(fun fn acc ->
-          match Filename.split_extension fn with
-          | (pkg, ".opam") when pkg <> "" ->
-            let version_from_opam_file =
-              let opam = Opam_file.load (Path.relative path fn |> Path.to_string) in
-              match Opam_file.get_field opam "version" with
-              | Some (String (_, s)) -> Some s
-              | _ -> None
-            in
-            (pkg,
-             { Package. name = pkg
-             ; path
-             ; version_from_opam_file
-             }) :: acc
-          | _ -> acc)
-      in
-      if String_set.mem "jbuild-ignore" files then
-        let ignore_set =
-          String_set.of_list
-            (Io.lines_of_file (Path.to_string (Path.relative path "jbuild-ignore")))
-        in
-        Dont_recurse_in
-          (ignore_set,
-           (pkgs,
-            String_set.fold ignore_set ~init:ignored ~f:(fun fn acc ->
-              Path.Set.add (Path.relative path fn) acc)))
-      else
-        Cont (pkgs, ignored))
+      String_set.fold files ~init:pkgs ~f:(fun fn acc ->
+        match Filename.split_extension fn with
+        | (pkg, ".opam") when pkg <> "" ->
+          let version_from_opam_file =
+            let opam = Opam_file.load (Path.relative path fn |> Path.to_string) in
+            match Opam_file.get_field opam "version" with
+            | Some (String (_, s)) -> Some s
+            | _ -> None
+          in
+          (pkg,
+           { Package. name = pkg
+           ; path
+           ; version_from_opam_file
+           }) :: acc
+        | _ -> acc))
   in
   let packages =
     String_map.of_alist_multi packages
@@ -219,30 +205,36 @@ let load ?(extra_ignored_subtrees=Path.Set.empty) () =
     |> Path.Map.map ~f:Scope.make
   in
   let rec walk dir jbuilds scope =
-    let path = File_tree.Dir.path dir in
-    let files = File_tree.Dir.files dir in
-    let sub_dirs = File_tree.Dir.sub_dirs dir in
-    let scope = Path.Map.find_default path scopes ~default:scope in
-    let jbuilds =
-      if String_set.mem "jbuild" files then
-        let jbuild = load ~dir:path ~scope in
-        jbuild :: jbuilds
-      else
-        jbuilds
-    in
-    let children, jbuilds =
-      String_map.fold sub_dirs ~init:([], jbuilds)
-        ~f:(fun ~key:_ ~data:dir (children, jbuilds) ->
-          if Path.Set.mem (File_tree.Dir.path dir) ignored_subtrees then
-            (children, jbuilds)
-          else
-            let child, jbuilds = walk dir jbuilds scope in
-            (child :: children, jbuilds))
-    in
-    (Alias.Node (path, children), jbuilds)
+    if File_tree.Dir.ignored dir ||
+       Path.Set.mem (File_tree.Dir.path dir) extra_ignored_subtrees then
+      None
+    else begin
+      let path = File_tree.Dir.path dir in
+      let files = File_tree.Dir.files dir in
+      let sub_dirs = File_tree.Dir.sub_dirs dir in
+      let scope = Path.Map.find_default path scopes ~default:scope in
+      let jbuilds =
+        if String_set.mem "jbuild" files then
+          let jbuild = load ~dir:path ~scope in
+          jbuild :: jbuilds
+        else
+          jbuilds
+      in
+      let children, jbuilds =
+        String_map.fold sub_dirs ~init:([], jbuilds)
+          ~f:(fun ~key:_ ~data:dir (children, jbuilds) ->
+            match walk dir jbuilds scope with
+            | None -> (children, jbuilds)
+            | Some (child, jbuilds) -> (child :: children, jbuilds))
+      in
+      Some (Alias.Node (path, children), jbuilds)
+    end
   in
   let root = File_tree.root ftree in
-  let tree, jbuilds = walk root [] Scope.empty in
+  let tree, jbuilds =
+    Option.value (walk root [] Scope.empty)
+      ~default:(Alias.Node (File_tree.Dir.path root, []), [])
+  in
   { file_tree = ftree
   ; tree
   ; jbuilds

--- a/src/jbuild_load.mli
+++ b/src/jbuild_load.mli
@@ -9,7 +9,6 @@ end
 
 type conf =
   { file_tree : File_tree.t
-  ; tree      : Alias.tree
   ; jbuilds   : Jbuilds.t
   ; packages  : Package.t String_map.t
   }

--- a/src/main.mli
+++ b/src/main.mli
@@ -7,6 +7,7 @@ type setup =
     stanzas      : (Path.t * Scope.t * Stanzas.t) list String_map.t
   ; contexts     : Context.t list
   ; packages     : Package.t String_map.t
+  ; file_tree    : File_tree.t
   }
 
 (* Returns [Error ()] if [pkg] is unknown *)

--- a/src/path.ml
+++ b/src/path.ml
@@ -424,3 +424,5 @@ let rm_rf =
 let change_extension ~ext t =
   let t = try Filename.chop_extension t with Not_found -> t in
   t ^ ext
+
+let pp = Format.pp_print_string

--- a/src/path.mli
+++ b/src/path.mli
@@ -111,3 +111,5 @@ val rm_rf : t -> unit
 
 (** Changes the extension of the filename (or adds an extension if there was none) *)
 val change_extension : ext:string -> t -> t
+
+val pp : t Fmt.t

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -410,11 +410,14 @@ module Deps = struct
     | File  s ->
       let path = Path.relative dir (expand_vars t ~scope ~dir s) in
       Build.path path
-      >>^ fun _ -> [path]
+      >>^ fun () -> [path]
     | Alias s ->
-      let path = Alias.file (Alias.make ~dir (expand_vars t ~scope ~dir s)) in
-      Build.path path
-      >>^ fun _ -> []
+      Alias.dep (Alias.make ~dir (expand_vars t ~scope ~dir s))
+      >>^ fun () -> []
+    | Alias_rec s ->
+      Alias.dep_rec ~loc:(String_with_vars.loc s) ~file_tree:t.file_tree
+        (Alias.make ~dir (expand_vars t ~scope ~dir s))
+      >>^ fun () -> []
     | Glob_files s -> begin
         let path = Path.relative dir (expand_vars t ~scope ~dir s) in
         match Glob_lexer.parse_string (Path.basename path) with

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -406,17 +406,20 @@ module Deps = struct
   open Build.O
   open Dep_conf
 
+  let make_alias t ~scope ~dir s =
+    Alias.of_path (Path.relative dir (expand_vars t ~scope ~dir s))
+
   let dep t ~scope ~dir = function
     | File  s ->
       let path = Path.relative dir (expand_vars t ~scope ~dir s) in
       Build.path path
       >>^ fun () -> [path]
     | Alias s ->
-      Alias.dep (Alias.make ~dir (expand_vars t ~scope ~dir s))
+      Alias.dep (make_alias t ~scope ~dir s)
       >>^ fun () -> []
     | Alias_rec s ->
       Alias.dep_rec ~loc:(String_with_vars.loc s) ~file_tree:t.file_tree
-        (Alias.make ~dir (expand_vars t ~scope ~dir s))
+        (make_alias t ~scope ~dir s)
       >>^ fun () -> []
     | Glob_files s -> begin
         let path = Path.relative dir (expand_vars t ~scope ~dir s) in

--- a/test/blackbox-tests/jbuild
+++ b/test/blackbox-tests/jbuild
@@ -71,3 +71,10 @@
   (action
    (chdir test-cases/copy_files
     (setenv JBUILDER ${bin:jbuilder} (run ${exe:cram.exe} run.t))))))
+
+(alias
+ ((name runtest)
+  (deps ((files_recursively_in test-cases/aliases)))
+  (action
+   (chdir test-cases/aliases
+    (setenv JBUILDER ${bin:jbuilder} (run ${exe:cram.exe} run.t))))))

--- a/test/blackbox-tests/test-cases/aliases/jbuild
+++ b/test/blackbox-tests/test-cases/aliases/jbuild
@@ -1,0 +1,9 @@
+(jbuild_version 1)
+
+(alias
+ ((name just-in-src)
+  (deps ((alias src/x)))))
+
+(alias
+ ((name everywhere)
+  (deps ((alias_rec x)))))

--- a/test/blackbox-tests/test-cases/aliases/run.t
+++ b/test/blackbox-tests/test-cases/aliases/run.t
@@ -13,7 +13,7 @@
   running in src
   $ $JBUILDER build -j1 --root . @plop
   File "<command-line>", line 1, characters 0-0:
-  Error: This recursive alias is empty.
+  Error: This alias is empty.
   Alias "plop" is not defined in . or any of its descendants.
   [1]
   $ $JBUILDER build -j1 --root . @truc/x

--- a/test/blackbox-tests/test-cases/aliases/run.t
+++ b/test/blackbox-tests/test-cases/aliases/run.t
@@ -1,0 +1,22 @@
+  $ $JBUILDER clean -j1 --root .
+  $ $JBUILDER build -j1 --root . @just-in-src
+  running in src
+  $ $JBUILDER clean -j1 --root .
+  $ $JBUILDER build -j1 --root . @everywhere
+  running in src/foo/bar
+  running in src/foo/baz
+  running in src
+  $ $JBUILDER clean -j1 --root .
+  $ $JBUILDER build -j1 --root . @x
+  running in src/foo/bar
+  running in src/foo/baz
+  running in src
+  $ $JBUILDER build -j1 --root . @plop
+  File "<command-line>", line 1, characters 0-0:
+  Error: This recursive alias is empty.
+  Alias "plop" is not defined in . or any of its descendants.
+  [1]
+  $ $JBUILDER build -j1 --root . @truc/x
+  File "<command-line>", line 1, characters 0-0:
+  Error: Don't know about directory truc!
+  [1]

--- a/test/blackbox-tests/test-cases/aliases/src/foo/bar/jbuild
+++ b/test/blackbox-tests/test-cases/aliases/src/foo/bar/jbuild
@@ -1,0 +1,5 @@
+(jbuild_version 1)
+
+(alias
+ ((name x)
+  (action (chdir ${ROOT} (echo "running in ${path-no-dep:.}\n")))))

--- a/test/blackbox-tests/test-cases/aliases/src/foo/baz/jbuild
+++ b/test/blackbox-tests/test-cases/aliases/src/foo/baz/jbuild
@@ -1,0 +1,5 @@
+(jbuild_version 1)
+
+(alias
+ ((name x)
+  (action (chdir ${ROOT} (echo "running in ${path-no-dep:.}\n")))))

--- a/test/blackbox-tests/test-cases/aliases/src/jbuild
+++ b/test/blackbox-tests/test-cases/aliases/src/jbuild
@@ -1,0 +1,5 @@
+(jbuild_version 1)
+
+(alias
+ ((name x)
+  (action (chdir ${ROOT} (echo "running in ${path-no-dep:.}\n")))))

--- a/test/blackbox-tests/test-cases/js_of_ocaml/run.t
+++ b/test/blackbox-tests/test-cases/js_of_ocaml/run.t
@@ -1,29 +1,29 @@
   $ $JBUILDER build -j1 --root . --dev bin/technologic.bc.js @install lib/x.cma.js lib/x__Y.cmo.js bin/z.cmo.js
-      ocamlopt .ppx/js_of_ocaml-ppx/ppx.exe
         ocamlc lib/stubs.o
+      ocamlopt .ppx/js_of_ocaml-ppx/ppx.exe
         ocamlc lib/x__.{cmi,cmo,cmt}
-           ppx bin/technologic.pp.ml
-           ppx bin/z.pp.ml
+    ocamlmklib lib/dllx_stubs.so,lib/libx_stubs.a
            ppx lib/x.pp.ml
            ppx lib/y.pp.ml
-    ocamlmklib lib/dllx_stubs.so,lib/libx_stubs.a
+           ppx bin/technologic.pp.ml
+           ppx bin/z.pp.ml
       ocamlopt lib/x__.{cmx,o}
-      ocamldep bin/technologic.depends.ocamldep-output
       ocamldep lib/x.depends.ocamldep-output
+      ocamldep bin/technologic.depends.ocamldep-output
+        ocamlc lib/x__Y.{cmi,cmo,cmt}
    js_of_ocaml .js/js_of_ocaml/js_of_ocaml.cma.js
    js_of_ocaml .js/stdlib/stdlib.cma.js
-        ocamlc lib/x__Y.{cmi,cmo,cmt}
    js_of_ocaml lib/x__Y.cmo.js
       ocamlopt lib/x__Y.{cmx,o}
         ocamlc lib/x.{cmi,cmo,cmt}
       ocamlopt lib/x.{cmx,o}
-        ocamlc bin/z.{cmi,cmo,cmt}
         ocamlc lib/x.cma
+        ocamlc bin/z.{cmi,cmo,cmt}
       ocamlopt lib/x.{a,cmxa}
-   js_of_ocaml bin/z.cmo.js
-        ocamlc bin/technologic.{cmi,cmo,cmt}
    js_of_ocaml lib/x.cma.js
    js_of_ocaml bin/technologic.bc.runtime.js
+   js_of_ocaml bin/z.cmo.js
+        ocamlc bin/technologic.{cmi,cmo,cmt}
       ocamlopt lib/x.cmxs
    js_of_ocaml bin/technologic.cmo.js
      jsoo_link bin/technologic.bc.js
@@ -34,17 +34,17 @@
   fix it
   $ $JBUILDER build -j1 --root . bin/technologic.bc.js @install
         ocamlc lib/x__.{cmi,cmo,cmt}
-        ocamlc lib/x__Y.{cmi,cmo,cmt}
       ocamlopt lib/x__.{cmx,o}
-        ocamlc lib/x.{cmi,cmo,cmt}
+        ocamlc lib/x__Y.{cmi,cmo,cmt}
       ocamlopt lib/x__Y.{cmx,o}
+        ocamlc lib/x.{cmi,cmo,cmt}
+      ocamlopt lib/x.{cmx,o}
         ocamlc lib/x.cma
         ocamlc bin/z.{cmi,cmo,cmt}
-      ocamlopt lib/x.{cmx,o}
-        ocamlc bin/technologic.{cmi,cmo,cmt}
       ocamlopt lib/x.{a,cmxa}
-        ocamlc bin/technologic.bc
+        ocamlc bin/technologic.{cmi,cmo,cmt}
       ocamlopt lib/x.cmxs
+        ocamlc bin/technologic.bc
    js_of_ocaml bin/technologic.bc.js
   $ $NODE ./_build/default/bin/technologic.bc.js
   buy it


### PR DESCRIPTION
Fixes #253.

ThisPR  removes the special _recursive aliases_ `runtest`, `install` and `doc`. Now all aliases are non-recursive. However, the interpretation of aliases on the command line is changed so that when the user types:

```sh
$ jbuilder build @src/x
```

this is interpreted as alias `x` in all descendant of `src` where it is defined. This way the interpretation of `@runtest`, `@install` and `@doc` is unchanged and users can define their own global aliases such as `examples`, `runtest-js`, ...

Inside jbuild files, one can use `(deps (... (alias_rec XXX) ...))` to get the same behavior.

In any case, when the alias is defined in none of the descendant of the specified directory, jbuilder reports an error. Except for `runtest`, `install` and `doc` as this could break existing invocations of jbuilder.

