### PR TITLE
Fix "Up" links to top-level index

### DIFF
--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -66,7 +66,7 @@ let lib_index sctx ~odoc ~dir ~(lib : Library.t) ~lib_public_name ~doc_dir ~modu
   let context = SC.context sctx in
   let generated_index_mld = dir ++ sprintf "%s-generated.mld" lib.name in
   let source_index_mld = dir ++ sprintf "%s.mld" lib.name in
-  let header = {|{%html:<nav><a href="..">Up</a></nav>%}|} in
+  let header = {|{%html:<nav><a href="../index.html">Up</a></nav>%}|} in
   SC.add_rule sctx
     (Build.if_file_exists source_index_mld
        ~then_:(Build.contents source_index_mld


### PR DESCRIPTION
When the docs are viewed locally, the URL `..` causes the browser to display a listing of the parent directory, instead of `../index.html`. The `../index.html` interpretation is only provided by web servers.