### PR TITLE
Add "S ." to .merlin when necessary

### DIFF
--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -796,6 +796,10 @@ Add it to your jbuild file to remove this warning.
         :: merlins
       | _ -> merlins)
     |> Merlin.merge_all
+    |> Option.map ~f:(fun (m : Merlin.t) ->
+      { m with source_dirs =
+                 Path.Set.add (Path.relative src_dir ".") m.source_dirs
+      })
     |> Option.iter ~f:(Merlin.add_rules sctx ~dir:ctx_dir);
     Option.iter (Utop.exe_stanzas stanzas) ~f:(fun (exe, all_modules) ->
       let dir = Utop.utop_exe_dir ~dir:ctx_dir in


### PR DESCRIPTION
Previously, "S. " wasn't added at all. This commit improves the behavior to add
this source whenever we can find at least one module whose original source isn't
from copied_files.

This isn't completely correct whenever some modules are from the jbuild dir, and
some are copied. Fixing this for real will wait until better support from merlin
itself.