### PR TITLE
Improve jbuilder exec

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -816,19 +816,18 @@ let exec =
   in
   let man =
     [ `S "DESCRIPTION"
-    ; `P {|$(b,jbuilder exec -- COMMAND) when COMMAND doesn't have a / will
-           behave in the same way as if you do:|}
+    ; `P {|$(b,jbuilder exec -- COMMAND) should behave in the same way as if you
+           do:|}
     ; `Pre "  \\$ jbuilder install\n\
            \  \\$ COMMAND"
-    ; `P {|In particular if you run $(b,jbuilder exec ocaml), you will have access
-           to the libraries defined in the workspace using your usual directives
-           ($(b,#require) for instance)|}
+    ; `P {|In particular if you run $(b,jbuilder exec ocaml), you will have
+           access to the libraries defined in the workspace using your usual
+           directives ($(b,#require) for instance)|}
     ; `P {|When a leading / is present in the command (absolute path), then the
-           path is interpreted relative to the build path of the specified
-           context|}
+           path is interpreted as an absolute path|}
     ; `P {|When a / is present at any other position (relative path), then the
-           path is interpeted as relative to the specified build context +
-           current working directory|}
+           path is interpreted as relative to the build context + current
+           working directory |}
     ; `Blocks help_secs
     ]
   in
@@ -846,11 +845,7 @@ let exec =
         let p = Path.of_string prog in
         let path =
           if i = 0 then (
-            String.drop_prefix prog ~prefix:"/"
-            |> Option.value_exn
-            |> Path.of_string
-            |> Path.parent
-            |> Path.append context.build_dir
+            Path.parent p
           ) else (
             let cwd_part =
               String.drop_prefix runcwd ~prefix:common.root

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -816,12 +816,15 @@ let exec =
   in
   let man =
     [ `S "DESCRIPTION"
-    ; `P {|$(b,jbuilder exec -- COMMAND) should behave in the same way as if you do:|}
+    ; `P {|$(b,jbuilder exec -- COMMAND) when COMMAND doesn't have a / will
+           behave in the same way as if you do:|}
     ; `Pre "  \\$ jbuilder install\n\
            \  \\$ COMMAND"
     ; `P {|In particular if you run $(b,jbuilder exec ocaml), you will have access
            to the libraries defined in the workspace using your usual directives
            ($(b,#require) for instance)|}
+    ; `P {|When a / is present in the command, then the path is interpreted
+           relative to the build path of the specified context|}
     ; `Blocks help_secs
     ]
   in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -828,6 +828,9 @@ let exec =
     ; `P {|When a / is present at any other position (relative path), then the
            path is interpreted as relative to the build context + current
            working directory |}
+    ; `P {|When this command is ran outside of the project root (in conjunction
+         with setting the $(b,--root) option manually), the path will always be
+         treated as relative to $(b,--root)|}
     ; `Blocks help_secs
     ]
   in
@@ -847,11 +850,11 @@ let exec =
           if i = 0 then (
             Path.parent p
           ) else (
-            let cwd_part =
-              String.drop_prefix runcwd ~prefix:common.root
-              |> Option.value_exn
-            in
-            Path.append (Path.relative context.build_dir cwd_part) (Path.parent p)
+            match String.drop_prefix runcwd ~prefix:common.root with
+            | None ->
+              Path.parent p
+            | Some s ->
+              Path.append (Path.relative context.build_dir s) (Path.parent p)
           ) in
         (Path.basename p, [path]) in
     match Bin.which ~path prog with

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -830,7 +830,13 @@ let exec =
     let log = Log.create () in
     let setup = Future.Scheduler.go ~log (Main.setup ~log common) in
     let context = Main.find_context_exn setup ~name:context in
-    let path = Config.local_install_bin_dir ~context:context.name :: context.path in
+    let (prog, path) =
+      if String.contains prog '/' then (
+        let p = Path.of_string prog in
+        (Path.basename p, [Path.append context.build_dir (Path.parent p)])
+      ) else (
+        (prog, Config.local_install_bin_dir ~context:context.name :: context.path)
+      ) in
     match Bin.which ~path prog with
     | None ->
       Format.eprintf "@{<Error>Error@}: Program %S not found!@." prog;

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -852,7 +852,7 @@ let exec =
           ) else (
             match String.drop_prefix runcwd ~prefix:common.root with
             | None ->
-              Path.parent p
+              Path.append context.build_dir (Path.parent p)
             | Some s ->
               Path.append (Path.relative context.build_dir s) (Path.parent p)
           ) in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -827,10 +827,8 @@ let exec =
            path is interpreted as an absolute path|}
     ; `P {|When a / is present at any other position (relative path), then the
            path is interpreted as relative to the build context + current
-           working directory |}
-    ; `P {|When this command is ran outside of the project root (in conjunction
-         with setting the $(b,--root) option manually), the path will always be
-         treated as relative to $(b,--root)|}
+           working directory (or the value of $(b,--root) when ran outside of
+           the project root)|}
     ; `Blocks help_secs
     ]
   in

--- a/src/import.ml
+++ b/src/import.ml
@@ -209,6 +209,15 @@ module String = struct
     len >= suffix_len &&
     sub s ~pos:(len - suffix_len) ~len:suffix_len = suffix
 
+  let drop_prefix s ~prefix =
+    if is_prefix s ~prefix then
+      if length s = length prefix then
+        Some ""
+      else
+        Some (sub s ~pos:(length prefix) ~len:(length s - length prefix - 1))
+    else
+      None
+
   include struct
     [@@@warning "-3"]
     let capitalize_ascii   = String.capitalize


### PR DESCRIPTION
When the path passed contianed to exec contains a '/', it will be interpreted
relative to the path of a build context (default context when absent)

Fix #152 