### PR TITLE
RFC update odoc rules

### DIFF
--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -410,7 +410,13 @@ module Gen(P : Params) = struct
       );
 
     (* Odoc *)
-    Odoc.setup_library_rules sctx lib ~dir ~requires ~modules ~dep_graph;
+    let mld_files =
+      String_set.fold files ~init:[] ~f:(fun fn acc ->
+        if Filename.check_suffix fn ".mld" then fn :: acc else acc)
+    in
+    Odoc.setup_library_rules sctx lib ~dir ~requires ~modules ~dep_graph
+      ~mld_files
+    ;
 
     let flags =
       match alias_module with

--- a/src/odoc.mli
+++ b/src/odoc.mli
@@ -8,6 +8,7 @@ val setup_library_rules
   -> Library.t
   -> dir:Path.t
   -> modules:Module.t String_map.t
+  -> mld_files:string list
   -> requires:(unit, Lib.t list) Build.t
   -> dep_graph:Ocamldep.dep_graph
   -> unit


### PR DESCRIPTION
odoc was updated recently to support arbitrary `.mld` files (cf. ocaml-doc/odoc#61 ), as a result the `--index-for` flag of the `html` command was removed.

This PR updates the rules to follow the new odoc conventions and seems to work on my test cases (it handles arbitrary `.mld` files), it's probably not as clean as it could be, but I'm hoping you guys can help with that :)

This probably shouldn't be merged (or at least, shouldn't be released on opam) before a new release of odoc is made (which should happen "soon"™).