### PR TITLE
Fix jbuilder rule in case of missing binaries

### DIFF
--- a/src/action.ml
+++ b/src/action.ml
@@ -131,9 +131,9 @@ end
 module Prog = struct
   module Not_found = struct
     type t =
-      { context: string
-      ; program: string
-      ; hint: string option
+      { context : string
+      ; program : string
+      ; hint    : string option
       }
 
     let raise { context ; program ; hint } =

--- a/src/action.mli
+++ b/src/action.mli
@@ -21,6 +21,8 @@ module Prog : sig
       ; program: string
       ; hint: string option
       }
+
+    val raise : t -> _
   end
 
   type t = (Path.t, Not_found.t) result

--- a/src/action.mli
+++ b/src/action.mli
@@ -15,7 +15,7 @@ end
 module Outputs : module type of struct include Action_intf.Outputs end
 
 module Maybe_prog : sig
-  type t = Found of Path.t | Not_found of string
+  type t = Found of Path.t | Not_found of exn
 end
 
 include Action_intf.Ast

--- a/src/action.mli
+++ b/src/action.mli
@@ -14,12 +14,20 @@ end
 
 module Outputs : module type of struct include Action_intf.Outputs end
 
-module Maybe_prog : sig
-  type t = Found of Path.t | Not_found of exn
+module Prog : sig
+  module Not_found : sig
+    type t =
+      { context: string
+      ; program: string
+      ; hint: string option
+      }
+  end
+
+  type t = (Path.t, Not_found.t) result
 end
 
 include Action_intf.Ast
-  with type program := Maybe_prog.t
+  with type program := Prog.t
   with type path    := Path.t
   with type string  := string
 

--- a/src/action.mli
+++ b/src/action.mli
@@ -14,12 +14,14 @@ end
 
 module Outputs : module type of struct include Action_intf.Outputs end
 
+(** result of the lookup of a program, the path to it or information about the
+    failure and possibly a hint how to fix it *)
 module Prog : sig
   module Not_found : sig
     type t =
-      { context: string
-      ; program: string
-      ; hint: string option
+      { context : string
+      ; program : string
+      ; hint    : string option
       }
 
     val raise : t -> _

--- a/src/action.mli
+++ b/src/action.mli
@@ -14,8 +14,12 @@ end
 
 module Outputs : module type of struct include Action_intf.Outputs end
 
+module Maybe_prog : sig
+  type t = Found of Path.t | Not_found of string
+end
+
 include Action_intf.Ast
-  with type program := Path.t
+  with type program := Maybe_prog.t
   with type path    := Path.t
   with type string  := string
 

--- a/src/artifacts.ml
+++ b/src/artifacts.ml
@@ -57,10 +57,10 @@ let create (context : Context.t) l ~f =
   ; local_libs
   }
 
-let binary t ?hint ?(in_the_tree=true) name =
+let binary t ?hint name =
   if not (Filename.is_relative name) then
     Ok (Path.absolute name)
-  else if in_the_tree then begin
+  else
     match String_map.find name t.local_bins with
     | Some path -> Ok path
     | None ->
@@ -74,18 +74,6 @@ let binary t ?hint ?(in_the_tree=true) name =
                 ?hint
                 ~in_the_tree:true
           }
-  end else begin
-    match Context.which t.context name with
-    | Some p -> Ok p
-    | None ->
-      Error
-        { fail = fun () ->
-            Utils.program_not_found name
-              ~context:t.context.name
-              ?hint
-              ~in_the_tree:false
-        }
-  end
 
 let file_of_lib t ~from ~lib ~file =
   match String_map.find lib t.local_libs with

--- a/src/artifacts.ml
+++ b/src/artifacts.ml
@@ -68,11 +68,10 @@ let binary t ?hint name =
       | Some p -> Ok p
       | None ->
         Error
-          { fail = fun () ->
-              Utils.program_not_found name
-                ~context:t.context.name
-                ?hint
-                ~in_the_tree:true
+          { Action.Prog.Not_found.
+            program = name
+          ; hint
+          ; context = t.context.Context.name
           }
 
 let file_of_lib t ~from ~lib ~file =

--- a/src/artifacts.mli
+++ b/src/artifacts.mli
@@ -16,7 +16,6 @@ val create
 val binary
   :  t
   -> ?hint:string
-  -> ?in_the_tree:bool (* default true *)
   -> string
   -> (Path.t, fail) result
 

--- a/src/artifacts.mli
+++ b/src/artifacts.mli
@@ -8,8 +8,7 @@ val create
   -> f:('a -> Jbuild.Stanza.t list)
   -> t
 
-(** A named artifact that is looked up in the PATH if not found in the tree or
-    [in_the_tree] is [false].
+(** A named artifact that is looked up in the PATH if not found in the tree
 
     If the name is an absolute path, it is used as it.
 *)

--- a/src/artifacts.mli
+++ b/src/artifacts.mli
@@ -17,7 +17,7 @@ val binary
   :  t
   -> ?hint:string
   -> string
-  -> (Path.t, fail) result
+  -> Action.Prog.t
 
 (** [file_of_lib t ~from name] a named artifact that is looked up in the given library.
 

--- a/src/build.ml
+++ b/src/build.ml
@@ -6,12 +6,6 @@ module Vspec = struct
   type 'a t = T : Path.t * 'a Vfile_kind.t -> 'a t
 end
 
-module Prog_spec = struct
-  type 'a t =
-    | Dep of Path.t
-    | Dyn of ('a -> Path.t)
-end
-
 type lib_dep_kind =
   | Optional
   | Required
@@ -194,13 +188,11 @@ let files_recursively_in ~dir ~file_tree =
 
 let store_vfile spec = Store_vfile spec
 
-let get_prog (prog : _ Prog_spec.t) =
-  let open Action.Maybe_prog in
-  match prog with
-  | Dep p -> path p >>> arr (fun _ -> Found p)
-  | Dyn f ->
-    arr (fun x -> try Found (f x) with e -> Not_found e)
-    >>> dyn_paths (arr (function Not_found _ -> [] | Found x -> [x]))
+let get_prog = function
+  | Ok p -> path p >>> arr (fun _ -> Ok p)
+  | Error f ->
+    arr (fun _ -> Error f)
+    >>> dyn_paths (arr (function Error _ -> [] | Ok x -> [x]))
 
 let prog_and_args ?(dir=Path.root) prog args =
   Paths (Arg_spec.add_deps args Pset.empty)

--- a/src/build.ml
+++ b/src/build.ml
@@ -8,7 +8,6 @@ end
 
 module Prog_spec = struct
   type 'a t =
-    | Missing of fail
     | Dep of Path.t
     | Dyn of ('a -> Path.t)
 end
@@ -198,9 +197,10 @@ let store_vfile spec = Store_vfile spec
 let get_prog (prog : _ Prog_spec.t) =
   let open Action.Maybe_prog in
   match prog with
-  | Missing s -> arr (fun _ -> Not_found (try s.fail () with e -> e))
   | Dep p -> path p >>> arr (fun _ -> Found p)
-  | Dyn f -> arr f >>> dyn_paths (arr (fun x -> [x])) >>^ (fun x -> Found x)
+  | Dyn f ->
+    arr (fun x -> try Found (f x) with e -> Not_found e)
+    >>> dyn_paths (arr (function Not_found _ -> [] | Found x -> [x]))
 
 let prog_and_args ?(dir=Path.root) prog args =
   Paths (Arg_spec.add_deps args Pset.empty)

--- a/src/build.mli
+++ b/src/build.mli
@@ -76,18 +76,12 @@ val fail : ?targets:Path.t list -> fail -> (_, _) t
     result is computed only once. *)
 val memoize : string -> (unit, 'a) t -> (unit, 'a) t
 
-module Prog_spec : sig
-  type 'a t =
-    | Dep of Path.t
-    | Dyn of ('a -> Path.t)
-end
-
 val run
   :  context:Context.t
   -> ?dir:Path.t (* default: [context.build_dir] *)
   -> ?stdout_to:Path.t
   -> ?extra_targets:Path.t list
-  -> 'a Prog_spec.t
+  -> Action.Prog.t
   -> 'a Arg_spec.t list
   -> ('a, Action.t) t
 

--- a/src/build.mli
+++ b/src/build.mli
@@ -78,7 +78,7 @@ val memoize : string -> (unit, 'a) t -> (unit, 'a) t
 
 module Prog_spec : sig
   type 'a t =
-    | Missing
+    | Missing of fail
     | Dep of Path.t
     | Dyn of ('a -> Path.t)
 end

--- a/src/build.mli
+++ b/src/build.mli
@@ -78,6 +78,7 @@ val memoize : string -> (unit, 'a) t -> (unit, 'a) t
 
 module Prog_spec : sig
   type 'a t =
+    | Missing
     | Dep of Path.t
     | Dyn of ('a -> Path.t)
 end

--- a/src/build.mli
+++ b/src/build.mli
@@ -78,7 +78,6 @@ val memoize : string -> (unit, 'a) t -> (unit, 'a) t
 
 module Prog_spec : sig
   type 'a t =
-    | Missing of fail
     | Dep of Path.t
     | Dyn of ('a -> Path.t)
 end

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -163,9 +163,7 @@ module Gen(P : Params) = struct
          (* We have to execute the rule in the library directory as the .o is produced in
             the current directory *)
          ~dir
-         (SC.resolve_program sctx ctx.c_compiler
-            (* The C compiler surely is not in the tree *)
-            ~in_the_tree:false)
+         (SC.resolve_program sctx ctx.c_compiler)
          [ S [A "-I"; Path ctx.stdlib_dir]
          ; As (SC.cxx_flags sctx)
          ; Dyn (fun (cxx_flags, libs) ->

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -108,7 +108,7 @@ module Gen(P : Params) = struct
          >>>
          Build.dyn_paths (Build.arr objs)
          >>>
-         Build.run ~context:ctx (Dep compiler)
+         Build.run ~context:ctx (Ok compiler)
            ~extra_targets:(
              match mode with
              | Byte -> []
@@ -138,7 +138,7 @@ module Gen(P : Params) = struct
          (* We have to execute the rule in the library directory as the .o is produced in
             the current directory *)
          ~dir
-         (Dep ctx.ocamlc)
+         (Ok ctx.ocamlc)
          [ As (Utils.g ())
          ; Dyn (fun (c_flags, libs) ->
              S [ Lib.c_include_flags libs
@@ -328,7 +328,7 @@ module Gen(P : Params) = struct
              >>>
              Build.run ~context:ctx
                ~extra_targets:targets
-               (Dep ctx.ocamlmklib)
+               (Ok ctx.ocamlmklib)
                [ As (Utils.g ())
                ; if custom then A "-custom" else As []
                ; A "-o"
@@ -390,7 +390,7 @@ module Gen(P : Params) = struct
           Ocaml_flags.get flags Native
           >>>
           Build.run ~context:ctx
-            (Dep ocamlopt)
+            (Ok ocamlopt)
             [ Dyn (fun flags -> As flags)
             ; A "-shared"; A "-linkall"
             ; A "-I"; Path dir
@@ -473,7 +473,7 @@ module Gen(P : Params) = struct
        (SC.expand_and_eval_set sctx ~scope ~dir link_flags ~standard:[])
        >>>
        Build.run ~context:ctx
-         (Dep compiler)
+         (Ok compiler)
          [ Dyn (fun (_, (flags,_)) -> As flags)
          ; A "-o"; Target exe
          ; Dyn (fun (_, (_, link_flags)) -> As (link_custom @ link_flags))

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -63,7 +63,7 @@ let build_cm sctx ?sandbox ~dynlink ~flags ~cm_kind ~(dep_graph:Ocamldep.dep_gra
          other_cm_files >>>
          requires &&&
          Ocaml_flags.get_for_cm flags ~cm_kind >>>
-         Build.run ~context:ctx (Dep compiler)
+         Build.run ~context:ctx (Ok compiler)
            ~extra_targets
            [ Dyn (fun (_, ocaml_flags) -> As ocaml_flags)
            ; cmt_args

--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -76,7 +76,7 @@ let rules sctx ~ml_kind ~dir ~item ~modules ~alias_module ~lib_interface_module 
   in
   let ctx = SC.context sctx in
   SC.add_rule sctx
-    (Build.run ~context:ctx (Dep ctx.ocamldep) [A "-modules"; S files]
+    (Build.run ~context:ctx (Ok ctx.ocamldep) [A "-modules"; S files]
        ~stdout_to:ocamldep_output);
   Build.memoize (Path.to_string ocamldep_output)
     (Build.lines_of ocamldep_output

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -87,7 +87,7 @@ let resolve_program_internal t ?hint ?(in_the_tree=true) bin =
 
 let resolve_program t ?hint ?in_the_tree bin =
   match resolve_program_internal t ?hint ?in_the_tree bin with
-  | Error fail -> Build.Prog_spec.Dyn (fun _ -> fail.fail ())
+  | Error _ -> Build.Prog_spec.Missing
   | Ok    path -> Build.Prog_spec.Dep path
 
 let create

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -87,7 +87,7 @@ let resolve_program_internal t ?hint ?(in_the_tree=true) bin =
 
 let resolve_program t ?hint ?in_the_tree bin =
   match resolve_program_internal t ?hint ?in_the_tree bin with
-  | Error _ -> Build.Prog_spec.Missing
+  | Error e -> Build.Prog_spec.Missing e
   | Ok    path -> Build.Prog_spec.Dep path
 
 let create

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -87,7 +87,7 @@ let resolve_program_internal t ?hint ?(in_the_tree=true) bin =
 
 let resolve_program t ?hint ?in_the_tree bin =
   match resolve_program_internal t ?hint ?in_the_tree bin with
-  | Error e -> Build.Prog_spec.Missing e
+  | Error fail -> Build.Prog_spec.Dyn (fun _ -> fail.fail ())
   | Ok    path -> Build.Prog_spec.Dep path
 
 let create

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -527,21 +527,23 @@ module Action = struct
         | Some ("exe"     , s) -> static_dep_exp acc (Path.relative dir s)
         | Some ("path"    , s) -> static_dep_exp acc (Path.relative dir s)
         | Some ("bin"     , s) -> begin
-            match A.binary (artifacts sctx) s with
+            match Artifacts.binary (artifacts sctx) s with
             | Ok path -> static_dep_exp acc path
             | Error fail -> add_fail acc fail
           end
         (* "findlib" for compatibility with Jane Street packages which are not yet updated
            to convert "findlib" to "lib" *)
         | Some (("lib"|"findlib"), s) -> begin
-            let lib_dep, res = A.file_of_lib (artifacts sctx) ~loc ~from:dir s in
+            let lib_dep, res =
+              Artifacts.file_of_lib (artifacts sctx) ~loc ~from:dir s in
             add_lib_dep acc lib_dep dep_kind;
             match res with
             | Ok path -> static_dep_exp acc path
             | Error fail -> add_fail acc fail
           end
         | Some ("libexec" , s) -> begin
-            let lib_dep, res = A.file_of_lib (artifacts sctx) ~loc ~from:dir s in
+            let lib_dep, res =
+              Artifacts.file_of_lib (artifacts sctx) ~loc ~from:dir s in
             add_lib_dep acc lib_dep dep_kind;
             match res with
             | Error fail -> add_fail acc fail

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -82,11 +82,11 @@ let expand_vars t ~scope ~dir s =
     Some (Path.reach ~from:dir (Path.append t.context.build_dir scope.Scope.root))
   | var -> String_map.find var t.vars)
 
-let resolve_program_internal t ?(in_the_tree=true) bin =
-  Artifacts.binary t.artifacts ~in_the_tree bin
+let resolve_program_internal t bin =
+  Artifacts.binary t.artifacts bin
 
-let resolve_program t ?hint ?in_the_tree bin =
-  match resolve_program_internal t ?in_the_tree bin with
+let resolve_program t ?hint bin =
+  match resolve_program_internal t bin with
   | Ok path -> Ok path
   | Error _fail ->
     Error

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -60,7 +60,8 @@ val sources_and_targets_known_so_far : t -> src_path:Path.t -> String_set.t
 
 (** [prog_spec t ?hint name] resolve a program. [name] is looked up in the
     workspace, if it is not found in the tree is is looked up in the PATH. If it
-    is not found at all, the resulting [Prog_spec.t] will fail when evaluated.
+    is not found at all, the resulting [Prog_spec.t] will either return the
+    resolved path or a record with details about the error and possibly a hint.
 
     [hint] should tell the user what to install when the program is not found.
 *)

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -58,10 +58,9 @@ val rules : t -> Build_interpret.Rule.t list
 
 val sources_and_targets_known_so_far : t -> src_path:Path.t -> String_set.t
 
-(** [prog_spec t ?hint ?in_the_tree name] resolve a program. If [in_the_tree] is [true]
-    (the default), [name] is looked up in the workspace. Otherwise, or if it is not found
-    in the tree is is looked up in the PATH. If it is not found at all, the resulting
-    [Prog_spec.t] will fail when evaluated.
+(** [prog_spec t ?hint name] resolve a program. [name] is looked up in the
+    workspace, if it is not found in the tree is is looked up in the PATH. If it
+    is not found at all, the resulting [Prog_spec.t] will fail when evaluated.
 
     [hint] should tell the user what to install when the program is not found.
 *)

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -70,7 +70,7 @@ val resolve_program
   -> ?hint:string
   -> ?in_the_tree:bool (* default true *)
   -> string
-  -> _ Build.Prog_spec.t
+  -> Action.Prog.t
 
 module Libs : sig
   val find : t -> from:Path.t -> string -> Lib.t option

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -68,7 +68,6 @@ val sources_and_targets_known_so_far : t -> src_path:Path.t -> String_set.t
 val resolve_program
   :  t
   -> ?hint:string
-  -> ?in_the_tree:bool (* default true *)
   -> string
   -> Action.Prog.t
 

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -88,12 +88,9 @@ let describe_target fn =
   | _ ->
     Path.to_string_maybe_quoted fn
 
-let program_not_found ?context ?(in_the_tree=false) ?hint prog =
-  die "@{<error>Error@}: Program %s not found in%s PATH%s%a" (maybe_quoted prog)
-    (if in_the_tree then
-       " the tree or in"
-     else
-       "")
+let program_not_found ?context ?hint prog =
+  die "@{<error>Error@}: Program %s not found in the tree or in PATH%s%a"
+    (maybe_quoted prog)
     (match context with
      | None -> ""
      | Some name -> sprintf " (context: %s)" name)

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -18,11 +18,9 @@ val jbuild_name_in : dir:Path.t -> string
 (** Nice description of a target *)
 val describe_target : Path.t -> string
 
-(** Raise an error about a program not found in the PATH. If [in_the_tree] is [true], then
-    assume that the program was looked up in the tree as well. *)
+(** Raise an error about a program not found in the PATH or in the tree *)
 val program_not_found
   :  ?context:string
-  -> ?in_the_tree:bool (* default: false *)
   -> ?hint:string
   -> string
   -> _


### PR DESCRIPTION
It would be nice to do this without modifying Prog_spec.

Fix #170 