### PR TITLE
Create @all alias

### DIFF
--- a/src/alias.ml
+++ b/src/alias.ml
@@ -47,7 +47,7 @@ let make name ~dir =
 let dep t = Build.path t.file
 
 let is_standard = function
-  | "runtest" | "install" | "doc" -> true
+  | "runtest" | "install" | "doc" | "exe" -> true
   | _ -> false
 
 let dep_rec ~loc ~file_tree t =
@@ -113,6 +113,7 @@ let default = make "DEFAULT"
 let runtest = make "runtest"
 let install = make "install"
 let doc     = make "doc"
+let exe     = make "exe"
 
 module Store = struct
   type entry =

--- a/src/alias.mli
+++ b/src/alias.mli
@@ -23,6 +23,7 @@ val default : dir:Path.t -> t
 val runtest : dir:Path.t -> t
 val install : dir:Path.t -> t
 val doc     : dir:Path.t -> t
+val exe     : dir:Path.t -> t
 
 val dep : t -> ('a, 'a) Build.t
 

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -1065,8 +1065,10 @@ Add it to your jbuild file to remove this warning.
        Build.write_file_dyn fn)
 
   let () =
+    let stanzas_to_consider_for_install =
+      SC.stanzas_to_consider_for_install sctx in
     let entries_per_package =
-      List.concat_map (SC.stanzas_to_consider_for_install sctx)
+      List.concat_map stanzas_to_consider_for_install
         ~f:(fun (dir, stanza) ->
           match stanza with
           | Library ({ public = Some { package; sub_dir; _ }; _ } as lib) ->
@@ -1078,6 +1080,17 @@ Add it to your jbuild file to remove this warning.
           | _ -> [])
       |> String_map.of_alist_multi
     in
+    let () =
+      let aliases = SC.aliases sctx in
+      List.iter stanzas_to_consider_for_install
+        ~f:(fun (dir, stanza) ->
+          match (stanza : Jbuild.Stanza.t) with
+          | Executables { names ; modes ; _ } ->
+            let ext = if modes.native then ".exe" else ".bc" in
+            List.map ~f:(fun name -> Path.relative dir (name ^ ext)) names
+            |> Alias.add_deps aliases (Alias.exe ~dir)
+          | _ -> ()
+        ) in
     String_map.iter (SC.packages sctx) ~f:(fun ~key:_ ~data:(pkg : Package.t) ->
       let stanzas = String_map.find_default pkg.name entries_per_package ~default:[] in
       install_file pkg.path pkg.name stanzas)

--- a/src/install.ml
+++ b/src/install.ml
@@ -31,6 +31,9 @@ module Section = struct
     | Man        -> "man"
     | Misc       -> "misc"
 
+  let pp fmt t =
+    Format.pp_print_string fmt (String.capitalize_ascii (to_string t))
+
   let t =
     let open Sexp.Of_sexp in
     enum
@@ -55,6 +58,15 @@ module Entry = struct
     ; dst     : string option
     ; section : Section.t
     }
+
+  let pp fmt t =
+    Format.fprintf fmt "@[<2>{@ src@ =@ %a@ ; dst@ =@ %a@ ;@ section@ =@ %a@ }@]"
+      Path.pp t.src
+      (fun fmt -> function
+       | None -> Format.pp_print_string fmt "None"
+       | Some s -> Format.fprintf fmt "%S" s)
+      t.dst
+      Section.pp t.section
 
   let make section ?dst src =
     let dst =

--- a/src/install.mli
+++ b/src/install.mli
@@ -1,3 +1,5 @@
+open! Import
+
 (** Opam install file *)
 
 module Section : sig
@@ -16,6 +18,8 @@ module Section : sig
     | Misc
 
   val t : t Sexp.Of_sexp.t
+
+  val pp : t Fmt.t
 end
 
 module Entry : sig
@@ -29,6 +33,8 @@ module Entry : sig
   val set_src : t -> Path.t -> t
 
   val relative_installed_path : t -> package:string -> Path.t
+
+  val pp : t Fmt.t
 end
 
 val files : Entry.t list -> Path.Set.t


### PR DESCRIPTION
This alias will try to build all library, executable, and user rule targets. This is an attempt to address #204. There's a couple of problems of doing this adequately:

* I'm probably not handling user rules with inferred dependencies correctly

* The alias itself isn't as well defined as we'd like. For example, some of the targets that it excludes are documentation building and test running targets. This seems like the most useful behavior, but it's clearly not *all* targets. Also, I'm not even sure if user rules should be built at all if they aren't required for building the libraries and executables.

Perhaps it makes sense to think of less all encompassing aliases such as `@libs`, `@exes`, or `@buildables` which will correspond to `libraries`, `executables`, or both, respectively.

Input appreciated @bobot @dra27 