### PR TITLE
Clarify use of the .exe extension

### DIFF
--- a/doc/quick-start.rst
+++ b/doc/quick-start.rst
@@ -31,7 +31,9 @@ And build it with:
 
     jbuilder build hello_world.exe
 
-The executable will be built as ``_build/default/hello_world.exe``
+The executable will be built as ``_build/default/hello_world.exe``. Note that
+native code executables will have the ``.exe`` extension on all platforms
+(including non-Windows systems).
 
 Building a hello world program using Lwt
 ========================================


### PR DESCRIPTION
.exe for executables is usually a windows-only convention; this threw me
for a moment and it seems worth calling out that this isn't platform
dependent.