### PR TITLE
Fix off by 1 error in String.drop_prefix

### DIFF
--- a/src/import.ml
+++ b/src/import.ml
@@ -214,7 +214,7 @@ module String = struct
       if length s = length prefix then
         Some ""
       else
-        Some (sub s ~pos:(length prefix) ~len:(length s - length prefix - 1))
+        Some (sub s ~pos:(length prefix) ~len:(length s - length prefix))
     else
       None
 


### PR DESCRIPTION
This is from the jbuilder exec branch. Which surprisingly wasn't broken by this.