### PR TITLE
[WIP] Sort out CI testing problem

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -53,9 +53,15 @@ case "$TARGET" in
     fi
   ;;
   build)
+    UPDATE_OPAM=0
     if [ $WITH_OPAM -eq 1 ] ; then
       echo -en "travis_fold:start:opam.deps\r"
       eval $(opam config env)
+      if [ $(opam pin list | wc -l) -ne 0 ] ; then
+        UPDATE_OPAM=1
+        opam pin remove jbuilder --no-action --yes
+        opam remove jbuilder --yes
+      fi
       opam list
       opam pin add jbuilder . --no-action --yes
       opam install ocaml-migrate-parsetree js_of_ocaml-ppx --yes
@@ -73,8 +79,10 @@ case "$TARGET" in
       _build/install/default/bin/jbuilder build @test/blackbox-tests/runtest-js && \
       ! _build/install/default/bin/jbuilder build @test/fail-with-background-jobs-running
       RESULT=$?
-      rm -rf ~/.opam
-      mv ~/.opam-start ~/.opam
+      if [ $UPDATE_OPAM -eq 0 ] ; then
+        rm -rf ~/.opam
+        mv ~/.opam-start ~/.opam
+      fi
       exit $RESULT
     fi
   ;;

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -25,6 +25,7 @@ case "$TARGET" in
     if [ $WITH_OPAM -eq 1 ] ; then
       echo -en "travis_fold:start:opam.init\r"
       if [ "$TRAVIS_OS_NAME" = "osx" ] ; then
+        brew update
         brew install aspcud
         PREFIX=/Users/travis
       else

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -62,6 +62,13 @@ case "$TARGET" in
         opam pin remove jbuilder --no-action --yes
         opam remove jbuilder --yes
       fi
+      DATE=$(date +%Y%m%d)
+      if [ ! -e ~/.opam/last-update ] || [ $(cat ~/.opam/last-update) != $DATE ] ; then
+        opam update --yes
+        echo $DATE> ~/.opam/last-update
+        UPDATE_OPAM=1
+        opam upgrade --yes
+      fi
       opam list
       opam pin add jbuilder . --no-action --yes
       opam install ocaml-migrate-parsetree js_of_ocaml-ppx --yes

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -56,13 +56,13 @@ case "$TARGET" in
     UPDATE_OPAM=0
     if [ $WITH_OPAM -eq 1 ] ; then
       echo -en "travis_fold:start:opam.deps\r"
+      DATE=$(date +%Y%m%d)
       eval $(opam config env)
       if [ $(opam pin list | wc -l) -ne 0 ] ; then
         UPDATE_OPAM=1
         opam pin remove jbuilder --no-action --yes
         opam remove jbuilder --yes
       fi
-      DATE=$(date +%Y%m%d)
       if [ ! -e ~/.opam/last-update ] || [ $(cat ~/.opam/last-update) != $DATE ] ; then
         opam update --yes
         echo $DATE> ~/.opam/last-update
@@ -70,6 +70,7 @@ case "$TARGET" in
         opam upgrade --yes
       fi
       opam list
+      echo "version: \"1.0+dev$DATE\"" >> jbuilder.opam
       opam pin add jbuilder . --no-action --yes
       opam install ocaml-migrate-parsetree js_of_ocaml-ppx --yes
       echo -en "travis_fold:end:opam.deps\r"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,17 +24,10 @@ matrix:
     env: OCAML_VERSION=4.05 OCAML_RELEASE=0 WITH_OPAM=0
     stage: Build
   - os: linux
-    env: OCAML_VERSION=4.05 OCAML_RELEASE=0 WITH_OPAM=1
-    stage: Test
-    addons:
-      apt:
-        packages:
-        - aspcud
-  - os: linux
     env: OCAML_VERSION=4.06 OCAML_RELEASE=0 WITH_OPAM=0
     stage: Build
   - os: linux
-    env: OCAML_VERSION=4.06 OCAML_RELEASE=0 WITH_OPAM=1
+    env: OCAML_VERSION=4.05 OCAML_RELEASE=0 WITH_OPAM=1
     stage: Test
     addons:
       apt:
@@ -53,8 +46,8 @@ matrix:
     env: OCAML_VERSION=4.05 OCAML_RELEASE=0 WITH_OPAM=0
     stage: Build_macOS
   - os: osx
-    env: OCAML_VERSION=4.05 OCAML_RELEASE=0 WITH_OPAM=1
-    stage: Test_macOS
+    env: OCAML_VERSION=4.06 OCAML_RELEASE=0 WITH_OPAM=0
+    stage: Build_macOS
   - os: osx
-    env: OCAML_VERSION=4.06 OCAML_RELEASE=0 WITH_OPAM=1
+    env: OCAML_VERSION=4.05 OCAML_RELEASE=0 WITH_OPAM=1
     stage: Test_macOS


### PR DESCRIPTION
Minor correction to the macOS test matrix (test building on 4.06; use 4.05 for opam test).

We can't run the tests on 4.06 at the moment in this setup because opam doesn't build out of the box with 4.06.0 (safe-string). When that dust settles, the obvious thing will be to migrate to opam 2.0.

The problem was two-fold before - there seems to have been a stale jbuilder pin which got into the cache somehow, which I've fixed by deleting it when it's detected. The other issue is that opam was never updating unless forced - it will now do an opam check once per day and refresh the opam installation if necessary.
