### PR TITLE
Fix jbuilder exec from sub dirs & utop

### DIFF
--- a/src/utop.ml
+++ b/src/utop.ml
@@ -11,7 +11,7 @@ let pp_ml fmt include_dirs =
   let pp_include fmt =
     let pp_sep fmt () = Format.fprintf fmt "@ ; " in
     Format.pp_print_list ~pp_sep (fun fmt p ->
-      Format.fprintf fmt "%S" (Path.to_string p)
+      Format.fprintf fmt "%S" (Path.to_absolute_filename p)
     ) fmt
   in
   Format.fprintf fmt "@[<v 2>Clflags.include_dirs :=@ [ %a@ ]@];@."


### PR DESCRIPTION
Fix #326 

The first patch is verbatim from diml. I did not want to apply it initially because it broke `jbuilder utop`, but I just had a second look and it's easily fixed by just using absolute dirs. I don't think there are any advantages to using absolute paths here.