### PR TITLE
Fix incremental compilation with ppx's

### DIFF
--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -791,7 +791,14 @@ module PP = struct
     add_rule sctx
       (libs
        >>>
-       Build.dyn_paths (Build.arr (Lib.archive_files ~mode ~ext_lib:ctx.ext_lib))
+       Build.dyn_paths (Build.arr (fun libs ->
+         List.rev_append
+           (Lib.archive_files ~mode ~ext_lib:ctx.ext_lib libs)
+           (List.filter_map libs ~f:(function
+              | Lib.Internal (dir, lib) ->
+                Some (Path.relative dir (lib.name ^ ctx.ext_lib))
+              | External _ ->
+                None))))
        >>>
        Build.run ~context:ctx (Ok compiler)
          [ A "-o" ; Target target


### PR DESCRIPTION
Same fix as 6a3c51c35899fe346804d34497dee594690c0ef6 but also for ppx's

I  just elected to do a similar fix to what @dra27 , but I think cleaner is to simply change the definition of `Lib.archive_files` to include the .a files.