### PR TITLE
Add tests for meta generation

### DIFF
--- a/test/blackbox-tests/jbuild
+++ b/test/blackbox-tests/jbuild
@@ -85,3 +85,10 @@
   (action
    (chdir test-cases/force-test
     (setenv JBUILDER ${bin:jbuilder} (run ${exe:cram.exe} run.t))))))
+
+(alias
+ ((name runtest)
+  (deps ((files_recursively_in test-cases/meta-gen)))
+  (action
+   (chdir test-cases/meta-gen
+    (setenv JBUILDER ${bin:jbuilder} (run ${exe:cram.exe} run.t))))))

--- a/test/blackbox-tests/test-cases/meta-gen/jbuild
+++ b/test/blackbox-tests/test-cases/meta-gen/jbuild
@@ -1,0 +1,27 @@
+(jbuild_version 1)
+
+(library
+ ((name foobar)
+  (libraries (bytes))
+  (public_name foobar)
+  (synopsis "contains \"quotes\"")))
+
+(library
+ ((name foobar_baz)
+  (public_name foobar.baz)
+  (libraries (bytes))
+  (modes (byte))
+  (synopsis "sub library with modes set to byte")))
+
+(library
+ ((name foobar_rewriter)
+  (synopsis "ppx rewriter")
+  (libraries (foobar))
+  (public_name foobar.rewriter)
+  (ppx_runtime_libraries (foobar_baz))
+  (kind ppx_rewriter)))
+
+(alias
+ ((name runtest)
+  (deps (META.foobar))
+  (action (echo "${read:META.foobar}"))))

--- a/test/blackbox-tests/test-cases/meta-gen/run.t
+++ b/test/blackbox-tests/test-cases/meta-gen/run.t
@@ -1,0 +1,32 @@
+  $ $JBUILDER runtest --force -j1 --root .
+  description = "contains \"quotes\""
+  requires = "bytes"
+  archive(byte) = "foobar.cma"
+  archive(native) = "foobar.cmxa"
+  plugin(byte) = "foobar.cma"
+  plugin(native) = "foobar.cmxs"
+  package "baz" (
+    directory = "baz"
+    description = "sub library with modes set to byte"
+    requires = "bytes"
+    archive(byte) = "foobar_baz.cma"
+    archive(native) = "foobar_baz.cmxa"
+    plugin(byte) = "foobar_baz.cma"
+    plugin(native) = "foobar_baz.cmxs"
+  )
+  package "rewriter" (
+    directory = "rewriter"
+    description = "ppx rewriter"
+    requires(ppx_driver) = "bytes foobar"
+    archive(ppx_driver,byte) = "foobar_rewriter.cma"
+    archive(ppx_driver,native) = "foobar_rewriter.cmxa"
+    plugin(ppx_driver,byte) = "foobar_rewriter.cma"
+    plugin(ppx_driver,native) = "foobar_rewriter.cmxs"
+    # This is what jbuilder uses to find out the runtime dependencies of
+    # a preprocessor
+    ppx_runtime_deps = "bytes foobar.baz"
+    # This line makes things transparent for people mixing preprocessors
+    # and normal dependencies
+    requires(-ppx_driver) = "bytes foobar.baz"
+    ppx(-ppx_driver,-custom_ppx) = "./ppx.exe --as-ppx"
+  )


### PR DESCRIPTION
Try to test as many aspects as possible: dependencies, synopsis, ppx, etc.

I noticed that this was easy to add without relying on cat if we have `--force`