### PR TITLE
Fix copy# for Microsoft C compiler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,8 @@ next
 
 - Fix doc generation when several private libraries have the same name (#369)
 
+- Fix copy# for C/C++ with Microsoft C compiler (#353)
+
 1.0+beta16 (05/11/2017)
 -----------------------
 

--- a/src/action.ml
+++ b/src/action.ml
@@ -596,7 +596,13 @@ let rec exec t ~ectx ~dir ~env_extra ~stdout_to ~stderr_to =
     Io.with_file_in (Path.to_string src) ~f:(fun ic ->
       Io.with_file_out (Path.to_string dst) ~f:(fun oc ->
         let fn = Path.drop_build_context src in
-        Printf.fprintf oc "# 1 %S\n" (Path.to_string fn);
+        let directive =
+          if List.mem (Path.extension fn) ~set:[".c"; ".cpp"; ".h"] then
+            "line"
+          else
+            ""
+        in
+        Printf.fprintf oc "#%s 1 %S\n" directive (Path.to_string fn);
         Io.copy_channels ic oc));
     return ()
   | System cmd ->

--- a/src/path.ml
+++ b/src/path.ml
@@ -426,4 +426,6 @@ let change_extension ~ext t =
   let t = try Filename.chop_extension t with Not_found -> t in
   t ^ ext
 
+let extension = Filename.extension
+
 let pp = Format.pp_print_string

--- a/src/path.mli
+++ b/src/path.mli
@@ -112,4 +112,6 @@ val rm_rf : t -> unit
 (** Changes the extension of the filename (or adds an extension if there was none) *)
 val change_extension : ext:string -> t -> t
 
+val extension : t -> string
+
 val pp : t Fmt.t

--- a/test/blackbox-tests/test-cases/copy_files/bar.c
+++ b/test/blackbox-tests/test-cases/copy_files/bar.c
@@ -1,0 +1,1 @@
+#include "bar.h"

--- a/test/blackbox-tests/test-cases/copy_files/include/bar.h
+++ b/test/blackbox-tests/test-cases/copy_files/include/bar.h
@@ -1,0 +1,1 @@
+int foo () {return 42;}

--- a/test/blackbox-tests/test-cases/copy_files/jbuild
+++ b/test/blackbox-tests/test-cases/copy_files/jbuild
@@ -12,3 +12,8 @@
 (executable
  ((name test)
   (libraries (foo))))
+
+(alias
+ ((name bar-source)
+  (deps (bar.h))
+  (action (echo "${read:bar.h}"))))

--- a/test/blackbox-tests/test-cases/copy_files/jbuild
+++ b/test/blackbox-tests/test-cases/copy_files/jbuild
@@ -1,6 +1,14 @@
 (jbuild_version 1)
 
 (copy_files# lexers/*.ml{,i})
+(copy_files# include/bar.h)
 
-(executables
- ((names (test))))
+(library
+ ((name foo)
+  (c_names (bar))
+  (modules ())
+  (wrapped false)))
+
+(executable
+ ((name test)
+  (libraries (foo))))

--- a/test/blackbox-tests/test-cases/copy_files/run.t
+++ b/test/blackbox-tests/test-cases/copy_files/run.t
@@ -10,3 +10,6 @@
     ocamlmklib dllfoo_stubs.so,libfoo_stubs.a
       ocamlopt test.{cmx,o}
       ocamlopt test.exe
+  $ $JBUILDER build -j1 @bar-source --root .
+  #line 1 "include/bar.h"
+  int foo () {return 42;}

--- a/test/blackbox-tests/test-cases/copy_files/run.t
+++ b/test/blackbox-tests/test-cases/copy_files/run.t
@@ -1,8 +1,12 @@
   $ $JBUILDER build -j1 test.exe .merlin --root . --debug-dependency-path
       ocamllex lexers/lexer1.ml
       ocamldep test.depends.ocamldep-output
+      ocamldep foo.depends.ocamldep-output
         ocamlc lexer1.{cmi,cmo,cmt}
+        ocamlc bar.o
+      ocamlopt foo.{a,cmxa}
       ocamlopt lexer1.{cmx,o}
         ocamlc test.{cmi,cmo,cmt}
+    ocamlmklib dllfoo_stubs.so,libfoo_stubs.a
       ocamlopt test.{cmx,o}
       ocamlopt test.exe


### PR DESCRIPTION
Microsoft CL doesn't support `#n` and requires the more strictly correct directive `#line`. I've done this by changing the behaviour of `copy#` depending on the file extension.