### PR TITLE
Availability of "num" depends on the OCaml version

### DIFF
--- a/src/findlib.ml
+++ b/src/findlib.ml
@@ -202,6 +202,7 @@ type present_or_not_available =
 type t =
   { stdlib_dir    : Path.t
   ; path          : Path.t list
+  ; builtins      : Meta.t String_map.t
   ; packages      : (string, present_or_not_available) Hashtbl.t
   }
 
@@ -210,6 +211,7 @@ let path t = t.path
 let create ~stdlib_dir ~path =
   { stdlib_dir
   ; path
+  ; builtins      = Meta.builtins ~stdlib_dir
   ; packages      = Hashtbl.create 1024
   }
 
@@ -313,7 +315,7 @@ let rec load_meta_rec t ~fq_name ~packages ~required_by =
           else
             loop dirs
       | [] ->
-        match String_map.find root_name Meta.builtins with
+        match String_map.find root_name t.builtins with
         | Some meta -> Some (t.stdlib_dir, meta)
         | None ->
           let required_by =
@@ -532,7 +534,7 @@ let root_packages t =
   in
   let pkgs =
     String_set.union pkgs
-      (String_set.of_list (String_map.keys Meta.builtins))
+      (String_set.of_list (String_map.keys t.builtins))
   in
   String_set.elements pkgs
 

--- a/src/findlib.ml
+++ b/src/findlib.ml
@@ -313,7 +313,7 @@ let rec load_meta_rec t ~fq_name ~packages ~required_by =
           else
             loop dirs
       | [] ->
-        match String_map.find root_name Meta.builtins with
+        match String_map.find root_name (Meta.builtins ~stdlib_dir:t.stdlib_dir) with
         | Some meta -> Some (t.stdlib_dir, meta)
         | None ->
           let required_by =
@@ -532,7 +532,8 @@ let root_packages t =
   in
   let pkgs =
     String_set.union pkgs
-      (String_set.of_list (String_map.keys Meta.builtins))
+      (String_set.of_list
+         (String_map.keys (Meta.builtins ~stdlib_dir:t.stdlib_dir)))
   in
   String_set.elements pkgs
 

--- a/src/findlib.ml
+++ b/src/findlib.ml
@@ -313,7 +313,7 @@ let rec load_meta_rec t ~fq_name ~packages ~required_by =
           else
             loop dirs
       | [] ->
-        match String_map.find root_name (Meta.builtins ~stdlib_dir:t.stdlib_dir) with
+        match String_map.find root_name Meta.builtins with
         | Some meta -> Some (t.stdlib_dir, meta)
         | None ->
           let required_by =
@@ -532,8 +532,7 @@ let root_packages t =
   in
   let pkgs =
     String_set.union pkgs
-      (String_set.of_list
-         (String_map.keys (Meta.builtins ~stdlib_dir:t.stdlib_dir)))
+      (String_set.of_list (String_map.keys Meta.builtins))
   in
   String_set.elements pkgs
 

--- a/src/meta.ml
+++ b/src/meta.ml
@@ -160,7 +160,7 @@ let archives name =
   ; plugin  "native" (name ^ ".cmxs")
   ]
 
-let builtins =
+let builtins ~stdlib_dir =
   let version = version "[distributed with Ocaml]" in
   let simple name ?dir ?(archive_name=name) deps =
     let archives = archives archive_name in
@@ -216,7 +216,13 @@ let builtins =
         ]
     }
   in
-  List.map [ compiler_libs; str; unix; bigarray; threads; num ] ~f:(fun t -> t.name, t)
+  let libs =
+    if Path.exists (Path.relative stdlib_dir "nums.cmxa") then
+      [ compiler_libs; str; unix; bigarray; threads; num ]
+    else
+      [ compiler_libs; str; unix; bigarray; threads ]
+  in
+  List.map libs ~f:(fun t -> t.name, t)
   |> String_map.of_alist_exn
 
 let string_of_action = function

--- a/src/meta.ml
+++ b/src/meta.ml
@@ -160,7 +160,7 @@ let archives name =
   ; plugin  "native" (name ^ ".cmxs")
   ]
 
-let builtins ~stdlib_dir =
+let builtins =
   let version = version "[distributed with Ocaml]" in
   let simple name ?dir ?(archive_name=name) deps =
     let archives = archives archive_name in
@@ -213,16 +213,11 @@ let builtins ~stdlib_dir =
         [ requires ["num.core"]
         ; version
         ; Package (simple "core" [] ~dir:"+" ~archive_name:"nums")
+        ; rule "exists_if" [] Set "nums.cmxa"
         ]
     }
   in
-  let libs =
-    if Path.exists (Path.relative stdlib_dir "nums.cmxa") then
-      [ compiler_libs; str; unix; bigarray; threads; num ]
-    else
-      [ compiler_libs; str; unix; bigarray; threads ]
-  in
-  List.map libs ~f:(fun t -> t.name, t)
+  List.map [ compiler_libs; str; unix; bigarray; threads; num ] ~f:(fun t -> t.name, t)
   |> String_map.of_alist_exn
 
 let string_of_action = function

--- a/src/meta.ml
+++ b/src/meta.ml
@@ -160,7 +160,7 @@ let archives name =
   ; plugin  "native" (name ^ ".cmxs")
   ]
 
-let builtins =
+let builtins ~stdlib_dir =
   let version = version "[distributed with Ocaml]" in
   let simple name ?dir ?(archive_name=name) deps =
     let archives = archives archive_name in
@@ -213,11 +213,16 @@ let builtins =
         [ requires ["num.core"]
         ; version
         ; Package (simple "core" [] ~dir:"+" ~archive_name:"nums")
-        ; rule "exists_if" [] Set "nums.cmxa"
         ]
     }
   in
-  List.map [ compiler_libs; str; unix; bigarray; threads; num ] ~f:(fun t -> t.name, t)
+  let libs =
+    if Path.exists (Path.relative stdlib_dir "nums.cma") then
+      [ compiler_libs; str; unix; bigarray; threads; num ]
+    else
+      [ compiler_libs; str; unix; bigarray; threads ]
+  in
+  List.map libs ~f:(fun t -> t.name, t)
   |> String_map.of_alist_exn
 
 let string_of_action = function

--- a/src/meta.ml
+++ b/src/meta.ml
@@ -217,6 +217,9 @@ let builtins ~stdlib_dir =
     }
   in
   let libs =
+    (* We do not rely on an "exists_if" ocamlfind variable,
+       because it would produce an error message mentioning
+       a "hidden" package (which could be confusing). *)
     if Path.exists (Path.relative stdlib_dir "nums.cma") then
       [ compiler_libs; str; unix; bigarray; threads; num ]
     else

--- a/src/meta.mli
+++ b/src/meta.mli
@@ -46,6 +46,6 @@ val simplify : t -> Simplified.t
 
 (** Builtin META files for libraries distributed with the compiler. For when ocamlfind is
     not installed. *)
-val builtins : t String_map.t
+val builtins : stdlib_dir:Path.t -> t String_map.t
 
 val pp : Format.formatter -> entry list -> unit

--- a/src/meta.mli
+++ b/src/meta.mli
@@ -46,6 +46,6 @@ val simplify : t -> Simplified.t
 
 (** Builtin META files for libraries distributed with the compiler. For when ocamlfind is
     not installed. *)
-val builtins : stdlib_dir:Path.t -> t String_map.t
+val builtins : t String_map.t
 
 val pp : Format.formatter -> entry list -> unit


### PR DESCRIPTION
(originally reported by @trefis)

When trying to link with `nums` in OCaml 4.06, the user gets
an unexpected error message if `ocamlfind` is not present,
because `jbuilder` hardcodes (in `src/meta.ml`) the set of
package that ship with the OCaml distribution.

This PR conditionally includes `nums` in the set, by testing
if the related archive file is present.