### PR TITLE
Add an (inline ...) stanza

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,7 @@ next
 - Build documentation for non public libraries (#306)
 
 - Add an `(inline)` allowing one to auto-generate part of a jbuild
-  file and keep it up-to-date
+  file and keep it up-to-date (#371)
 
 1.0+beta16 (05/11/2017)
 -----------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,10 +19,13 @@ next
   absolute path but with the context's environment set appropriately. Lastly,
   `jbuilder exec` will change the root as to which paths are relative using the
   `-root` option. (#286)
-  
+
 - Fix `jbuilder rules` printing rules when some binaries are missing (#292)
 
 - Build documentation for non public libraries (#306)
+
+- Add an `(inline)` allowing one to auto-generate part of a jbuild
+  file and keep it up-to-date
 
 1.0+beta16 (05/11/2017)
 -----------------------

--- a/Makefile
+++ b/Makefile
@@ -33,28 +33,12 @@ clean:
 doc:
 	cd doc && sphinx-build . _build
 
-CMDS = $(shell $(BIN) --help=plain | \
-  sed -n '/COMMANDS/,/OPTIONS/p' | sed -En 's/^       ([a-z-]+)/\1/p')
-
 update-jbuilds: $(BIN)
-	sed -n '1,/;;GENERATED/p' doc/jbuild > doc/jbuild.tmp
-	{ for cmd in $(CMDS); do \
-	    echo -ne "\n"\
-	"(rule\n"\
-	"  ((targets (jbuilder-$$cmd.1))\n"\
-	"   (action  (with-stdout-to $$""{@}\n"\
-	"             (run $$""{bin:jbuilder} $$cmd --help=groff)))))\n"\
-	"\n"\
-	"(install\n"\
-	" ((section man)\n"\
-	"  (files (jbuilder-$$cmd.1))))\n"; \
-	  done } >> doc/jbuild.tmp
-	rm -f doc/jbuild
-	mv doc/jbuild.tmp doc/jbuild
+	$(BIN) build --dev @jbuild
 
 accept-corrections:
 	for i in `find . -name \*.corrected`; do \
-	  cp $$i $${i/.corrected}; \
+	  cp $$i $${i%.corrected}; \
 	done
 
 .DEFAULT_GOAL := default

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -21,6 +21,7 @@ type common =
   ; target_prefix    : string
   ; only_packages    : String_set.t option
   ; capture_outputs  : bool
+  ; diff_command     : string option
   ; (* Original arguments for the external-lib-deps hint *)
     orig_args        : string list
   }
@@ -38,6 +39,7 @@ let set_common c ~targets =
   if c.root <> Filename.current_dir_name then
     Sys.chdir c.root;
   Clflags.workspace_root := Sys.getcwd ();
+  Clflags.diff_command := c.diff_command;
   Clflags.external_lib_deps_hint :=
     List.concat
       [ ["jbuilder"; "external-lib-deps"; "--missing"]
@@ -153,6 +155,7 @@ let common =
         verbose
         no_buffer
         workspace_file
+        diff_command
         (root, only_packages, orig)
     =
     let root, to_cwd =
@@ -178,6 +181,7 @@ let common =
     ; root
     ; orig_args
     ; target_prefix = String.concat ~sep:"" (List.map to_cwd ~f:(sprintf "%s/"))
+    ; diff_command
     ; only_packages =
         Option.map only_packages
           ~f:(fun s -> String_set.of_list (String.split s ~on:','))
@@ -304,6 +308,12 @@ let common =
                $ only_packages
                $ frop))
   in
+  let diff_command =
+    Arg.(value
+         & opt (some string) None
+         & info ["diff-command"] ~docs
+             ~doc:"Shell command to use to diff files")
+  in
   Term.(const make
         $ concurrency
         $ ddep_path
@@ -313,6 +323,7 @@ let common =
         $ verbose
         $ no_buffer
         $ workspace_file
+        $ diff_command
         $ root_and_only_packages
        )
 

--- a/doc/jbuild
+++ b/doc/jbuild
@@ -9,104 +9,105 @@
  ((section man)
   (files (jbuilder.1))))
 
-;; Run "make update-jbuilds" to update the rest of this file
-;;GENERATED
+(inline (run bash ${path:update-jbuild.sh} ${bin:jbuilder}))
 
 (rule
-  ((targets (jbuilder-build.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} build --help=groff)))))
+ ((targets (jbuilder-build.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} build --help=groff)))))
 
 (install
  ((section man)
   (files (jbuilder-build.1))))
 
 (rule
-  ((targets (jbuilder-clean.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} clean --help=groff)))))
+ ((targets (jbuilder-clean.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} clean --help=groff)))))
 
 (install
  ((section man)
   (files (jbuilder-clean.1))))
 
 (rule
-  ((targets (jbuilder-exec.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} exec --help=groff)))))
+ ((targets (jbuilder-exec.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} exec --help=groff)))))
 
 (install
  ((section man)
   (files (jbuilder-exec.1))))
 
 (rule
-  ((targets (jbuilder-external-lib-deps.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} external-lib-deps --help=groff)))))
+ ((targets (jbuilder-external-lib-deps.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} external-lib-deps --help=groff)))))
 
 (install
  ((section man)
   (files (jbuilder-external-lib-deps.1))))
 
 (rule
-  ((targets (jbuilder-install.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} install --help=groff)))))
+ ((targets (jbuilder-install.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} install --help=groff)))))
 
 (install
  ((section man)
   (files (jbuilder-install.1))))
 
 (rule
-  ((targets (jbuilder-installed-libraries.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} installed-libraries --help=groff)))))
+ ((targets (jbuilder-installed-libraries.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} installed-libraries --help=groff)))))
 
 (install
  ((section man)
   (files (jbuilder-installed-libraries.1))))
 
 (rule
-  ((targets (jbuilder-rules.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} rules --help=groff)))))
+ ((targets (jbuilder-rules.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} rules --help=groff)))))
 
 (install
  ((section man)
   (files (jbuilder-rules.1))))
 
 (rule
-  ((targets (jbuilder-runtest.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} runtest --help=groff)))))
+ ((targets (jbuilder-runtest.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} runtest --help=groff)))))
 
 (install
  ((section man)
   (files (jbuilder-runtest.1))))
 
 (rule
-  ((targets (jbuilder-subst.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} subst --help=groff)))))
+ ((targets (jbuilder-subst.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} subst --help=groff)))))
 
 (install
  ((section man)
   (files (jbuilder-subst.1))))
 
 (rule
-  ((targets (jbuilder-uninstall.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} uninstall --help=groff)))))
+ ((targets (jbuilder-uninstall.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} uninstall --help=groff)))))
 
 (install
  ((section man)
   (files (jbuilder-uninstall.1))))
 
 (rule
-  ((targets (jbuilder-utop.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} utop --help=groff)))))
+ ((targets (jbuilder-utop.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} utop --help=groff)))))
 
 (install
  ((section man)
   (files (jbuilder-utop.1))))
+
+(end)

--- a/doc/jbuild.rst
+++ b/doc/jbuild.rst
@@ -551,11 +551,19 @@ Inline blocks are written as follow:
 When reading jbuild files, ``inline`` and ``end`` stanzas are
 ignored. However, when building the ``jbuild`` alias, jbuilder will
 run ``<action>`` and make sure that the output of the action matches
-``<stanzas>``. If not, jbuilder will update the jbuild file in place
-and print a diff.
+``<stanzas>``. If not, jbuilder will update the jbuild file in place,
+print a diff and fail. You then have to restart the build to pick up
+the changes.
 
 You can use this feature to auto-generate a part of a jbuild file and
-keep it up to date.
+keep it up to date. In order to make sure that the jbuild files are
+up-to-date, simply build the ``jbuild`` alias. For instance you can
+use this command line to build both the package and check the jbuild
+files:
+
+..code:: bash
+
+    $ jbuilder build @install @jbuild
 
 Common items
 ============

--- a/doc/jbuild.rst
+++ b/doc/jbuild.rst
@@ -537,6 +537,26 @@ The difference between ``copy_files`` and ``copy_files#`` is the same
 as the difference between the ``copy`` and ``copy#`` action. See the
 `User actions`_ section for more details.
 
+inline
+------
+
+Inline blocks are written as follow:
+
+.. code:: scheme
+
+    (inline <action>)
+    <stanzas>
+    (end)
+
+When reading jbuild files, ``inline`` and ``end`` stanzas are
+ignored. However, when building the ``jbuild`` alias, jbuilder will
+run ``<action>`` and make sure that the output of the action matches
+``<stanzas>``. If not, jbuilder will update the jbuild file in place
+and print a diff.
+
+You can use this feature to auto-generate a part of a jbuild file and
+keep it up to date.
+
 Common items
 ============
 

--- a/doc/update-jbuild.sh
+++ b/doc/update-jbuild.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# CR-someday jdimino: maybe it's possible to get cmdliner to print that directly
+
+set -e -o pipefail
+
+jbuilder=$1
+
+CMDS=$($jbuilder --help=plain | \
+           sed -n '/COMMANDS/,/OPTIONS/p' | sed -En 's/^       ([a-z-]+)/\1/p')
+
+for cmd in $CMDS; do
+    cat <<EOF
+
+(rule
+ ((targets (jbuilder-$cmd.1))
+  (action  (with-stdout-to \${@}
+            (run \${bin:jbuilder} $cmd --help=groff)))))
+
+(install
+ ((section man)
+  (files (jbuilder-$cmd.1))))
+EOF
+done
+
+echo

--- a/src/action_intf.ml
+++ b/src/action_intf.ml
@@ -29,5 +29,6 @@ module type Ast = sig
     | Remove_tree    of path
     | Mkdir          of path
     | Digest_files   of path list
+    | Update_jbuild  of path * path list
 end
 

--- a/src/clflags.ml
+++ b/src/clflags.ml
@@ -10,3 +10,4 @@ let workspace_root = ref "."
 let external_lib_deps_hint = ref []
 let capture_outputs = ref true
 let debug_backtraces = ref false
+let diff_command = ref None

--- a/src/clflags.mli
+++ b/src/clflags.mli
@@ -35,3 +35,6 @@ val capture_outputs : bool ref
 
 (** Always print backtraces, to help debugging jbuilder itself *)
 val debug_backtraces : bool ref
+
+(** Command to use to diff things *)
+val diff_command : string option ref

--- a/src/diff.ml
+++ b/src/diff.ml
@@ -1,0 +1,37 @@
+open Import
+
+let ( >>= ) = Future.( >>= )
+
+let print file1 file2 =
+  let loc = Loc.in_file (Path.to_string file1) in
+  let fallback () =
+    die "%aFiles \"%s\" and \"%s\" differ." Loc.print loc
+      (Path.to_string file1) (Path.to_string file2)
+  in
+  let normal_diff () =
+    match Bin.which "diff" with
+    | None -> fallback ()
+    | Some prog ->
+      Format.eprintf "%a@?" Loc.print loc;
+      Future.run Strict (Path.to_string prog) ["-u"; Path.to_string file1; Path.to_string file2]
+      >>= fun () ->
+      die "diff reported no differences on \"%s\" and \"%s\""
+        (Path.to_string file1) (Path.to_string file2)
+  in
+  match !Clflags.diff_command with
+  | Some cmd ->
+    let sh, arg = Utils.system_shell_exn ~needed_to:"print diffs" in
+    let q fn = Filename.quote (Path.to_string fn) in
+    let cmd = sprintf "%s %s %s" cmd (q file1) (q file2) in
+    Future.run Strict (Path.to_string sh) [arg; cmd]
+    >>= fun () ->
+    die "command reported no differences: %s" cmd
+  | None ->
+    match Bin.which "patdiff" with
+    | None -> normal_diff ()
+    | Some prog ->
+      Future.run Strict (Path.to_string prog)
+        ["-keep-whitespace"; "-location-style"; "omake"; "-unrefined"; Path.to_string file1; Path.to_string file2]
+      >>= fun () ->
+      (* Use "diff" if "patdiff" reported no differences *)
+      normal_diff ()

--- a/src/diff.mli
+++ b/src/diff.mli
@@ -1,0 +1,2 @@
+(** Diff two files that are expected not to match. *)
+val print : Path.t -> Path.t -> _ Future.t

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -246,11 +246,15 @@ module Stanza : sig
     | Install     of Install_conf.t
     | Alias       of Alias_conf.t
     | Copy_files  of Copy_files.t
+    | Inline      of Loc.t * Action.Unexpanded.t
+    | End         of Loc.t
 end
 
 module Stanzas : sig
   type t = Stanza.t list
 
-  val parse : Scope.t -> Sexp.Ast.t list -> t
+  type syntax = OCaml | Plain
+
+  val parse : syntax:syntax -> Scope.t -> Sexp.Ast.t list -> t
   val lib_names : (_ * _ * t) list -> String_set.t
 end

--- a/src/jbuild_load.ml
+++ b/src/jbuild_load.ml
@@ -145,7 +145,7 @@ end
                Did you forgot to call [Jbuild_plugin.V*.send]?"
             (Path.to_string file);
         let sexps = Sexp_lexer.Load.many (Path.to_string generated_jbuild) in
-        return (dir, scope, Stanzas.parse scope sexps))
+        return (dir, scope, Stanzas.parse ~syntax:OCaml scope sexps))
     |> Future.all
 end
 
@@ -159,7 +159,7 @@ let load ~dir ~scope =
   let file = Path.relative dir "jbuild" in
   match Sexp_lexer.Load.many_or_ocaml_script (Path.to_string file) with
   | Sexps sexps ->
-    Jbuilds.Literal (dir, scope, Stanzas.parse scope sexps)
+    Jbuilds.Literal (dir, scope, Stanzas.parse scope ~syntax:Plain sexps)
   | Ocaml_script ->
     Script { dir; scope }
 

--- a/test/blackbox-tests/jbuild
+++ b/test/blackbox-tests/jbuild
@@ -134,3 +134,10 @@
   (action
    (chdir test-cases/select
     (setenv JBUILDER ${bin:jbuilder} (run ${exe:cram.exe} run.t))))))
+
+(alias
+ ((name runtest)
+  (deps ((files_recursively_in test-cases/inline)))
+  (action
+   (chdir test-cases/inline
+    (setenv JBUILDER ${bin:jbuilder} (run ${exe:cram.exe} run.t))))))

--- a/test/blackbox-tests/test-cases/inline/jbuild.in
+++ b/test/blackbox-tests/test-cases/inline/jbuild.in
@@ -1,0 +1,4 @@
+(jbuild_version 1)
+
+(inline (echo "toto"))
+(end)

--- a/test/blackbox-tests/test-cases/inline/run.t
+++ b/test/blackbox-tests/test-cases/inline/run.t
@@ -1,0 +1,15 @@
+  $ cat jbuild.in > jbuild
+  $ cat jbuild
+  (jbuild_version 1)
+  
+  (inline (echo "toto"))
+  (end)
+  $ $JBUILDER build --root . -j1 --diff-command false @jbuild
+            sh (internal) (exit 1)
+  /bin/sh -c 'false '\''jbuild.old'\'' '\''jbuild'\'''
+  [1]
+  $ cat jbuild
+  (jbuild_version 1)
+  
+  (inline (echo "toto"))
+  toto(end)


### PR DESCRIPTION
This feature adds an `(inline ...)` stanza whose purpose is to provide similar functionalities to `(include ...)`, except that the inlcuded contents is written directly in the jbuild file. Jbuilder make sure that the inlined contents is kept up-to-date. This is how it works:

```
$ cat jbuild
(inline (echo "FOO"))
(end)
$ jbuilder build @jbuild
     patdiff (internal) (exit 1)
/home/dim/.opam/4.05.0/bin/patdiff -keep-whitespace -location-style omake -unrefined jbuild.old jbuild
------ jbuild.old
++++++ jbuild
File "jbuild.old", line 2, characters 0-1:
 |(inline (echo "FOO"))
-|(end)
+|FOO(end)
$ cat jbuild 
(inline (echo "FOO"))
FOO(end)
```

This is used in `doc/jbuild`. It should cover many cases when one has a long list of repeated rules. Compared to a classic `(include ...)` stanza, we have to commit the generated rules, but on the other hand it's easier to debug as we see the generated rules directly in the jbuild file.

This feature is intended for cases such as camomile, where we have a lot of rules generated, but the pattern is very specific to one use case, so it doesn't justify writing a plugin and having the actual rules under the eyes makes debugging easier.