### PR TITLE
Fix Path.descendent

### DIFF
--- a/src/path.ml
+++ b/src/path.ml
@@ -188,8 +188,9 @@ module Local = struct
     | _ ->
       let of_len = String.length of_ in
       let t_len = String.length t in
-      if (t_len = of_len && t = of_) ||
-         (t_len >= of_len && t.[of_len] = '/' && String.is_prefix t ~prefix:of_) then
+      if t_len = of_len then
+        Option.some_if (t = of_) t
+      else if (t_len >= of_len && t.[of_len] = '/' && String.is_prefix t ~prefix:of_) then
         Some (String.sub t ~pos:(of_len + 1) ~len:(t_len - of_len - 1))
       else
         None

--- a/test/unit-tests/jbuild
+++ b/test/unit-tests/jbuild
@@ -37,3 +37,10 @@
          (glob_files ${SCOPE_ROOT}/src/*.cmi)
          (glob_files ${SCOPE_ROOT}/vendor/re/*.cmi)))
   (action (chdir ${SCOPE_ROOT} (run ${exe:expect_test.exe} ${<})))))
+
+(alias
+ ((name runtest)
+  (deps (path.mlt
+         (glob_files ${SCOPE_ROOT}/src/*.cmi)
+         (glob_files ${SCOPE_ROOT}/vendor/re/*.cmi)))
+  (action (chdir ${SCOPE_ROOT} (run ${exe:expect_test.exe} ${<})))))

--- a/test/unit-tests/path.mlt
+++ b/test/unit-tests/path.mlt
@@ -1,5 +1,4 @@
 (* -*- tuareg -*- *)
-
 open Jbuilder;;
 open Import;;
 
@@ -10,37 +9,23 @@ let r = Path.(relative root);;
 Path.(let p = relative root "foo" in descendant p ~of_:p)
 [%%expect{|
 val r : string -> Jbuilder.Path.t = <fun>
-Exception: Invalid_argument "String.sub / Bytes.sub".
-Raised at file "pervasives.ml", line 33, characters 25-45
-Called from file "string.ml", line 47, characters 2-23
-Called from file "src/path.ml", line 193, characters 13-71
-Called from file "toplevel/toploop.ml", line 180, characters 17-56
+- : Jbuilder.Path.t option = Some foo
 |}]
 
 (* different strings but same length *)
 Path.(descendant (relative root "foo") ~of_:(relative root "bar"))
 [%%expect{|
-Exception: Invalid_argument "index out of bounds".
-Raised by primitive operation at file "src/path.ml", line 192, characters 29-39
-Called from file "toplevel/toploop.ml", line 180, characters 17-56
+- : Jbuilder.Path.t option = None
 |}]
 
 Path.(descendant (r "foo") ~of_:(r "foo/"))
 [%%expect{|
-Exception: Invalid_argument "String.sub / Bytes.sub".
-Raised at file "pervasives.ml", line 33, characters 25-45
-Called from file "string.ml", line 47, characters 2-23
-Called from file "src/path.ml", line 193, characters 13-71
-Called from file "toplevel/toploop.ml", line 180, characters 17-56
+- : Jbuilder.Path.t option = Some foo
 |}]
 
 Path.(descendant (r "foo/") ~of_:(r "foo"))
 [%%expect{|
-Exception: Invalid_argument "String.sub / Bytes.sub".
-Raised at file "pervasives.ml", line 33, characters 25-45
-Called from file "string.ml", line 47, characters 2-23
-Called from file "src/path.ml", line 193, characters 13-71
-Called from file "toplevel/toploop.ml", line 180, characters 17-56
+- : Jbuilder.Path.t option = Some foo
 |}]
 
 Path.(descendant (r "foo/bar") ~of_:(r "foo"))

--- a/test/unit-tests/path.mlt
+++ b/test/unit-tests/path.mlt
@@ -1,0 +1,64 @@
+(* -*- tuareg -*- *)
+
+open Jbuilder;;
+open Import;;
+
+let r = Path.(relative root);;
+
+#install_printer Path.pp;;
+
+Path.(let p = relative root "foo" in descendant p ~of_:p)
+[%%expect{|
+val r : string -> Jbuilder.Path.t = <fun>
+Exception: Invalid_argument "String.sub / Bytes.sub".
+Raised at file "pervasives.ml", line 33, characters 25-45
+Called from file "string.ml", line 47, characters 2-23
+Called from file "src/path.ml", line 193, characters 13-71
+Called from file "toplevel/toploop.ml", line 180, characters 17-56
+|}]
+
+(* different strings but same length *)
+Path.(descendant (relative root "foo") ~of_:(relative root "bar"))
+[%%expect{|
+Exception: Invalid_argument "index out of bounds".
+Raised by primitive operation at file "src/path.ml", line 192, characters 29-39
+Called from file "toplevel/toploop.ml", line 180, characters 17-56
+|}]
+
+Path.(descendant (r "foo") ~of_:(r "foo/"))
+[%%expect{|
+Exception: Invalid_argument "String.sub / Bytes.sub".
+Raised at file "pervasives.ml", line 33, characters 25-45
+Called from file "string.ml", line 47, characters 2-23
+Called from file "src/path.ml", line 193, characters 13-71
+Called from file "toplevel/toploop.ml", line 180, characters 17-56
+|}]
+
+Path.(descendant (r "foo/") ~of_:(r "foo"))
+[%%expect{|
+Exception: Invalid_argument "String.sub / Bytes.sub".
+Raised at file "pervasives.ml", line 33, characters 25-45
+Called from file "string.ml", line 47, characters 2-23
+Called from file "src/path.ml", line 193, characters 13-71
+Called from file "toplevel/toploop.ml", line 180, characters 17-56
+|}]
+
+Path.(descendant (r "foo/bar") ~of_:(r "foo"))
+[%%expect{|
+- : Jbuilder.Path.t option = Some bar
+|}]
+
+Path.(descendant Path.root ~of_:(r "foo"))
+[%%expect{|
+- : Jbuilder.Path.t option = None
+|}]
+
+Path.(descendant Path.root ~of_:Path.root)
+[%%expect{|
+- : Jbuilder.Path.t option = Some 
+|}]
+
+Path.(descendant (r "foo") ~of_:Path.root)
+[%%expect{|
+- : Jbuilder.Path.t option = Some foo
+|}]


### PR DESCRIPTION
It doesn't work when the paths are equal or have the same length.

@toots can you try the x branch with this patch applied? Also, it would be nice to understand which paths causing the crash on windows. It seems strange that this a windows only issue. So if you have the bandwidth to add some printf'ing here and find the offending paths that would be wonderful.