### PR TITLE
Add dummy module to make copy_files test pass on 4.02.3

### DIFF
--- a/test/blackbox-tests/test-cases/copy_files/jbuild
+++ b/test/blackbox-tests/test-cases/copy_files/jbuild
@@ -3,14 +3,20 @@
 (copy_files# lexers/*.ml{,i})
 (copy_files# include/bar.h)
 
+(rule
+ ((targets (dummy.ml))
+  (deps ())
+  (action (with-stdout-to ${@} (echo "")))))
+
 (library
  ((name foo)
   (c_names (bar))
-  (modules ())
+  (modules (dummy))
   (wrapped false)))
 
 (executable
  ((name test)
+  (modules (:standard \ dummy))
   (libraries (foo))))
 
 (alias

--- a/test/blackbox-tests/test-cases/copy_files/run.t
+++ b/test/blackbox-tests/test-cases/copy_files/run.t
@@ -2,12 +2,14 @@
       ocamllex lexers/lexer1.ml
       ocamldep test.depends.ocamldep-output
       ocamldep foo.depends.ocamldep-output
-        ocamlc lexer1.{cmi,cmo,cmt}
         ocamlc bar.o
-      ocamlopt foo.{a,cmxa}
-      ocamlopt lexer1.{cmx,o}
-        ocamlc test.{cmi,cmo,cmt}
+        ocamlc dummy.{cmi,cmo,cmt}
     ocamlmklib dllfoo_stubs.so,libfoo_stubs.a
+        ocamlc lexer1.{cmi,cmo,cmt}
+      ocamlopt dummy.{cmx,o}
+        ocamlc test.{cmi,cmo,cmt}
+      ocamlopt lexer1.{cmx,o}
+      ocamlopt foo.{a,cmxa}
       ocamlopt test.{cmx,o}
       ocamlopt test.exe
   $ $JBUILDER build -j1 @bar-source --root .


### PR DESCRIPTION
@dra27 this seems than just skipping the test. If we want to test the case of no modules we can simply add that as a different test case to skipped for 4.02.3.