### PR TITLE
Fix c_compiler parsing for OCaml >= 4.06.0

### DIFF
--- a/src/context.ml
+++ b/src/context.ml
@@ -354,12 +354,13 @@ let create ~(kind : Kind.t) ~path ~base_env ~env_extra ~name ~merlin
     let c_compiler, ocamlc_cflags, ocamlopt_cflags =
       match get_opt "c_compiler" with
       | Some c_compiler -> (* >= 4.06 *)
-        let c_compiler, discarded_args = split_prog c_compiler in
-        if String.length discarded_args > 0 then (
-          Format.eprintf "@{<warning>Warning@}: c_compiler contains arguments \
-                          that will be discarded: %S" discarded_args
-        );
-        (c_compiler, get "ocamlc_cflags", get "ocamlopt_cflags")
+        let c_compiler, extra_args = split_prog c_compiler in
+        let args var =
+          if String.length extra_args > 0 then
+            sprintf "%s %s" extra_args (get var)
+          else
+            get var in
+        (c_compiler, args "ocamlc_cflags", args "ocamlopt_cflags")
       | None ->
         let c_compiler, ocamlc_cflags = split_prog (get "bytecomp_c_compiler") in
         let _, ocamlopt_cflags = split_prog (get "native_c_compiler") in

--- a/src/context.ml
+++ b/src/context.ml
@@ -337,25 +337,30 @@ let create ~(kind : Kind.t) ~path ~base_env ~env_extra ~name ~merlin
       else
         env,env_extra
     in
+    let split_prog s =
+      let len = String.length s in
+      let rec loop i =
+        if i = len then
+          (s, "")
+        else
+          match s.[i] with
+          | ' ' | '\t' ->
+            (String.sub s ~pos:0 ~len:i,
+             String.sub s ~pos:i ~len:(len - i))
+          | _ -> loop (i + 1)
+      in
+      loop 0
+    in
     let c_compiler, ocamlc_cflags, ocamlopt_cflags =
       match get_opt "c_compiler" with
       | Some c_compiler -> (* >= 4.06 *)
+        let c_compiler, discarded_args = split_prog c_compiler in
+        if String.length discarded_args > 0 then (
+          Format.eprintf "@{<warning>Warning@}: c_compiler contains arguments \
+                          that will be discarded: %S" discarded_args
+        );
         (c_compiler, get "ocamlc_cflags", get "ocamlopt_cflags")
       | None ->
-        let split_prog s =
-          let len = String.length s in
-          let rec loop i =
-            if i = len then
-              (s, "")
-            else
-              match s.[i] with
-              | ' ' | '\t' ->
-                (String.sub s ~pos:0 ~len:i,
-                 String.sub s ~pos:i ~len:(len - i))
-              | _ -> loop (i + 1)
-          in
-          loop 0
-        in
         let c_compiler, ocamlc_cflags = split_prog (get "bytecomp_c_compiler") in
         let _, ocamlopt_cflags = split_prog (get "native_c_compiler") in
         (c_compiler, ocamlc_cflags, ocamlopt_cflags)


### PR DESCRIPTION
c_compiler can still contain arguments that need to be parsed. Unfortunately,
they must be discarded because it's possible they're already present in
{ocamlc,ocamlopt}_flags

@yminsky if you can, see if this fixes the issue for you (and you see the warning)