### PR TITLE
Add promote actions and include stanzas

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,12 @@ next
 - Simplify generated META files: do not generate the transitive
   closure of dependencies in META files (#405)
 
+- Add an `(include ...)` stanza allowing one to include another
+  non-generated jbuild file in the current file (#402)
+
+- Add a `(promote (<file1> as <file2>) ...)` action allowing one to
+  promote generated files as source files (#402)
+
 1.0+beta16 (05/11/2017)
 -----------------------
 

--- a/Makefile
+++ b/Makefile
@@ -33,24 +33,8 @@ clean:
 doc:
 	cd doc && sphinx-build . _build
 
-CMDS = $(shell $(BIN) --help=plain | \
-  sed -n '/COMMANDS/,/OPTIONS/p' | sed -En 's/^       ([a-z-]+)/\1/p')
-
 update-jbuilds: $(BIN)
-	sed -n '1,/;;GENERATED/p' doc/jbuild > doc/jbuild.tmp
-	{ for cmd in $(CMDS); do \
-	    echo -ne "\n"\
-	"(rule\n"\
-	"  ((targets (jbuilder-$$cmd.1))\n"\
-	"   (action  (with-stdout-to $$""{@}\n"\
-	"             (run $$""{bin:jbuilder} $$cmd --help=groff)))))\n"\
-	"\n"\
-	"(install\n"\
-	" ((section man)\n"\
-	"  (files (jbuilder-$$cmd.1))))\n"; \
-	  done } >> doc/jbuild.tmp
-	rm -f doc/jbuild
-	mv doc/jbuild.tmp doc/jbuild
+	$(BIN) build --dev @jbuild --promote copy
 
 accept-corrections:
 	for i in `find . -name \*.corrected`; do \

--- a/doc/jbuild
+++ b/doc/jbuild
@@ -9,104 +9,12 @@
  ((section man)
   (files (jbuilder.1))))
 
-;; Run "make update-jbuilds" to update the rest of this file
-;;GENERATED
+(include jbuild.inc)
 
 (rule
-  ((targets (jbuilder-build.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} build --help=groff)))))
+ (with-stdout-to jbuild.inc.gen
+  (run bash ${path:update-jbuild.sh} ${bin:jbuilder})))
 
-(install
- ((section man)
-  (files (jbuilder-build.1))))
-
-(rule
-  ((targets (jbuilder-clean.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} clean --help=groff)))))
-
-(install
- ((section man)
-  (files (jbuilder-clean.1))))
-
-(rule
-  ((targets (jbuilder-exec.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} exec --help=groff)))))
-
-(install
- ((section man)
-  (files (jbuilder-exec.1))))
-
-(rule
-  ((targets (jbuilder-external-lib-deps.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} external-lib-deps --help=groff)))))
-
-(install
- ((section man)
-  (files (jbuilder-external-lib-deps.1))))
-
-(rule
-  ((targets (jbuilder-install.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} install --help=groff)))))
-
-(install
- ((section man)
-  (files (jbuilder-install.1))))
-
-(rule
-  ((targets (jbuilder-installed-libraries.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} installed-libraries --help=groff)))))
-
-(install
- ((section man)
-  (files (jbuilder-installed-libraries.1))))
-
-(rule
-  ((targets (jbuilder-rules.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} rules --help=groff)))))
-
-(install
- ((section man)
-  (files (jbuilder-rules.1))))
-
-(rule
-  ((targets (jbuilder-runtest.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} runtest --help=groff)))))
-
-(install
- ((section man)
-  (files (jbuilder-runtest.1))))
-
-(rule
-  ((targets (jbuilder-subst.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} subst --help=groff)))))
-
-(install
- ((section man)
-  (files (jbuilder-subst.1))))
-
-(rule
-  ((targets (jbuilder-uninstall.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} uninstall --help=groff)))))
-
-(install
- ((section man)
-  (files (jbuilder-uninstall.1))))
-
-(rule
-  ((targets (jbuilder-utop.1))
-   (action  (with-stdout-to ${@}
-             (run ${bin:jbuilder} utop --help=groff)))))
-
-(install
- ((section man)
-  (files (jbuilder-utop.1))))
+(alias
+ ((name jbuild)
+  (action (promote (jbuild.inc.gen as jbuild.inc)))))

--- a/doc/jbuild.inc
+++ b/doc/jbuild.inc
@@ -1,0 +1,100 @@
+
+(rule
+ ((targets (jbuilder-build.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} build --help=groff)))))
+
+(install
+ ((section man)
+  (files (jbuilder-build.1))))
+
+(rule
+ ((targets (jbuilder-clean.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} clean --help=groff)))))
+
+(install
+ ((section man)
+  (files (jbuilder-clean.1))))
+
+(rule
+ ((targets (jbuilder-exec.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} exec --help=groff)))))
+
+(install
+ ((section man)
+  (files (jbuilder-exec.1))))
+
+(rule
+ ((targets (jbuilder-external-lib-deps.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} external-lib-deps --help=groff)))))
+
+(install
+ ((section man)
+  (files (jbuilder-external-lib-deps.1))))
+
+(rule
+ ((targets (jbuilder-install.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} install --help=groff)))))
+
+(install
+ ((section man)
+  (files (jbuilder-install.1))))
+
+(rule
+ ((targets (jbuilder-installed-libraries.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} installed-libraries --help=groff)))))
+
+(install
+ ((section man)
+  (files (jbuilder-installed-libraries.1))))
+
+(rule
+ ((targets (jbuilder-rules.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} rules --help=groff)))))
+
+(install
+ ((section man)
+  (files (jbuilder-rules.1))))
+
+(rule
+ ((targets (jbuilder-runtest.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} runtest --help=groff)))))
+
+(install
+ ((section man)
+  (files (jbuilder-runtest.1))))
+
+(rule
+ ((targets (jbuilder-subst.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} subst --help=groff)))))
+
+(install
+ ((section man)
+  (files (jbuilder-subst.1))))
+
+(rule
+ ((targets (jbuilder-uninstall.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} uninstall --help=groff)))))
+
+(install
+ ((section man)
+  (files (jbuilder-uninstall.1))))
+
+(rule
+ ((targets (jbuilder-utop.1))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} utop --help=groff)))))
+
+(install
+ ((section man)
+  (files (jbuilder-utop.1))))
+

--- a/doc/jbuild.rst
+++ b/doc/jbuild.rst
@@ -537,6 +537,34 @@ The difference between ``copy_files`` and ``copy_files#`` is the same
 as the difference between the ``copy`` and ``copy#`` action. See the
 `User actions`_ section for more details.
 
+include
+-------
+
+The ``include`` stanza allows to include the contents of another file
+into the current jbuild file. Currently, the included file cannot be
+generated and must be present in the source tree. This feature is
+intended to be used in conjunction with promotion, when parts of a
+jbuild file are to be generated.
+
+For instance:
+
+.. code:: scheme
+
+    (include jbuild.inc)
+
+    (rule (with-stdout-to jbuild.inc.gen (run ./gen-jbuild.exe)))
+
+    (alias
+     ((name   jbuild)
+      (action (promote (jbuild.inc.gen as jbuild.inc)))))
+
+With this jbuild file, running jbuilder as follow will replace the
+``jbuild.inc`` file in the source tree by the generated one:
+
+.. code:: shell
+
+    $ jbuilder build @jbuild --promote copy
+
 Common items
 ============
 
@@ -986,6 +1014,12 @@ The following constructions are available:
   and ``cmd`` on Windows
 - ``(bash <cmd>)`` to execute a command using ``/bin/bash``. This is obviously
   not very portable
+- ``(promote <files-to-promote>)`` copy generated files to the source
+  tree. See `Promotion`_ for more details
+- ``(promote-if <files-to-promote>)`` is the same as ``(promote
+  <files-to-promote>)`` except that it does nothing when the files to
+  copy don't exist. This can be used with command that only produce a
+  correction when differences are found
 
 As mentioned ``copy#`` inserts a line directive at the beginning of
 the destination file. More precisely, it inserts the following line:
@@ -1102,6 +1136,31 @@ is global to all build contexts, simply use an absolute filename:
       (action (run test.exe ${<}))))
 
 .. _ocaml-syntax:
+
+Promotion
+---------
+
+The ``(promote (<file1> as <file2>) (<file3> as <file4>) ...)`` action
+can be used to copy generated files to the source tree.
+
+This method is used when one wants to comit a generated file that is
+independent of the systems where it is generated. Typically this can
+be used to:
+
+- cut dependencies and/or speed up the build in release mode: we use
+  the file in the source tree rather than re-generate it
+- support bootstrap cycles
+
+How jbuilder interprets promotions can be controlled using the
+``--promote`` command line argument. The following behaviors are
+available:
+
+- ``--promote check``: this is the default. Jbuilder just checks that
+  the two files given in each ``(<a> as <b>)`` form are equal. If not,
+  it prints a diff
+- ``--promote ignore``: ``promote`` actions are simply ignored
+- ``--promote copy``: when the two files are different, jbuilder
+  prints a diff and copies ``<a>`` to ``<b>`` directly in the source tree
 
 OCaml syntax
 ============

--- a/doc/jbuild.rst
+++ b/doc/jbuild.rst
@@ -1140,7 +1140,8 @@ is global to all build contexts, simply use an absolute filename:
 Promotion
 ---------
 
-The ``(promote (<file1> as <file2>) (<file3> as <file4>) ...)`` action
+The ``(promote (<file1> as <file2>) (<file3> as <file4>) ...)`` and
+``(promote-if (<file1> as <file2>) (<file3> as <file4>) ...)`` actions
 can be used to copy generated files to the source tree.
 
 This method is used when one wants to commit a generated file that is
@@ -1150,6 +1151,8 @@ be used to:
 - cut dependencies and/or speed up the build in release mode: we use
   the file in the source tree rather than re-generate it
 - support bootstrap cycles
+- simplify the review when the generated code is easier to review than
+  the generator
 
 How jbuilder interprets promotions can be controlled using the
 ``--promote`` command line argument. The following behaviors are
@@ -1161,6 +1164,9 @@ available:
 - ``--promote ignore``: ``promote`` actions are simply ignored
 - ``--promote copy``: when the two files are different, jbuilder
   prints a diff and copies ``<a>`` to ``<b>`` directly in the source tree
+
+Note that ``-p/--for-release-of-packages`` implies ``--promote
+ignore``.
 
 OCaml syntax
 ============

--- a/doc/jbuild.rst
+++ b/doc/jbuild.rst
@@ -1143,7 +1143,7 @@ Promotion
 The ``(promote (<file1> as <file2>) (<file3> as <file4>) ...)`` action
 can be used to copy generated files to the source tree.
 
-This method is used when one wants to comit a generated file that is
+This method is used when one wants to commit a generated file that is
 independent of the systems where it is generated. Typically this can
 be used to:
 

--- a/doc/update-jbuild.sh
+++ b/doc/update-jbuild.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# CR-someday jdimino: maybe it's possible to get cmdliner to print that directly
+
+set -e -o pipefail
+
+jbuilder=$1
+
+CMDS=$($jbuilder --help=plain | \
+           sed -n '/COMMANDS/,/OPTIONS/p' | sed -En 's/^       ([a-z-]+)/\1/p')
+
+for cmd in $CMDS; do
+    cat <<EOF
+
+(rule
+ ((targets (jbuilder-$cmd.1))
+  (action  (with-stdout-to \${@}
+            (run \${bin:jbuilder} $cmd --help=groff)))))
+
+(install
+ ((section man)
+  (files (jbuilder-$cmd.1))))
+EOF
+done
+
+echo

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -222,14 +222,16 @@ follows:
 
     build: [["jbuilder" "build" "-p" name "-j" jobs]]
 
-``-p pkg`` is a shorthand for ``--root . --only-packages pkg``. ``-p``
-is the short version of ``--for-release-of-packages``.
+``-p pkg`` is a shorthand for ``--root . --only-packages pkg --promote
+ignore``. ``-p`` is the short version of
+``--for-release-of-packages``.
 
 This has the following effects:
 
 -  it tells jbuilder to build everything that is installable and to
    ignore packages other than ``name`` defined in your project
 -  it sets the root to prevent jbuilder from looking it up
+-  it ignores promotion to cut down dependencies and speed up the build
 -  it uses whatever concurrency option opam provides
 
 Note that ``name`` and ``jobs`` are variables expanded by opam. ``name``

--- a/src/action.ml
+++ b/src/action.ml
@@ -12,6 +12,8 @@ module Outputs = struct
     | Outputs -> "outputs"
 end
 
+module Promote_mode = Action_intf.Promote_mode
+
 module type Sexpable = sig
   type t
   val t : t Sexp.Of_sexp.t
@@ -28,6 +30,14 @@ module Make_ast
      with type string  := String.t) =
 struct
   include Ast
+
+  let promoted_file sexp =
+    match sexp with
+    | List (_, [src; Atom (_, "as"); dst]) ->
+      { Promote. src = Path.t src; dst = Path.t dst }
+    | _ ->
+      of_sexp_error sexp
+        "(<file1> as <file2>) expected"
 
   let rec t sexp =
     let path = Path.t and string = String.t in
@@ -59,8 +69,15 @@ struct
       ; cstr "system" (string @> nil) (fun cmd -> System cmd)
       ; cstr "bash"   (string @> nil) (fun cmd -> Bash   cmd)
       ; cstr "write-file" (path @> string @> nil) (fun fn s -> Write_file (fn, s))
+      ; cstr_rest "promote" nil promoted_file
+          (fun files -> Promote { mode = Always; files })
+      ; cstr_rest "promote-if" nil promoted_file
+          (fun files -> Promote { mode = If_corrected_file_exists; files })
       ]
       sexp
+
+  let sexp_of_promoted_file (file : Promote.file) =
+    Sexp.List [Path.sexp_of_t file.src; Atom "as"; Path.sexp_of_t file.dst]
 
   let rec sexp_of_t : _ -> Sexp.t =
     let path = Path.sexp_of_t and string = String.sexp_of_t in
@@ -93,6 +110,10 @@ struct
     | Remove_tree x -> List [Atom "remove-tree"; path x]
     | Mkdir x       -> List [Atom "mkdir"; path x]
     | Digest_files paths -> List [Atom "digest-files"; List (List.map paths ~f:path)]
+    | Promote { mode = Always; files } ->
+      List (Atom "promote" :: List.map files ~f:sexp_of_promoted_file)
+    | Promote { mode = If_corrected_file_exists; files } ->
+      List (Atom "promote-if" :: List.map files ~f:sexp_of_promoted_file)
 
   let run prog args = Run (prog, args)
   let chdir path t = Chdir (path, t)
@@ -149,6 +170,12 @@ module Make_mapper
     | Remove_tree x -> Remove_tree (f_path x)
     | Mkdir x -> Mkdir (f_path x)
     | Digest_files x -> Digest_files (List.map x ~f:f_path)
+    | Promote p ->
+      let files =
+        List.map p.files ~f:(fun { Src.Promote. src; dst } ->
+          { Dst.Promote.src = f_path src; dst = f_path dst })
+      in
+      Promote { mode = p.mode; files }
 end
 
 module Prog = struct
@@ -395,6 +422,15 @@ module Unexpanded = struct
         end
       | Digest_files x ->
         Digest_files (List.map x ~f:(E.path ~dir ~f))
+      | Promote p ->
+        let files =
+          List.map p.files ~f:(fun { Promote.src; dst } ->
+            { Unresolved.Promote.
+              src = E.path ~dir ~f src
+            ; dst = Path.drop_build_context (E.path ~dir ~f dst)
+            })
+        in
+        Promote { mode = p.mode; files }
   end
 
   module E = struct
@@ -496,6 +532,15 @@ module Unexpanded = struct
       Mkdir res
     | Digest_files x ->
       Digest_files (List.map x ~f:(E.path ~dir ~f))
+    | Promote p ->
+      let files =
+        List.map p.files ~f:(fun { Promote.src; dst } ->
+          { Partial.Promote.
+            src = E.path ~dir ~f src
+          ; dst = E.path ~dir ~f dst
+          })
+      in
+      Promote { mode = p.mode; files }
 end
 
 let fold_one_step t ~init:acc ~f =
@@ -517,7 +562,8 @@ let fold_one_step t ~init:acc ~f =
   | Rename _
   | Remove_tree _
   | Mkdir _
-  | Digest_files _ -> acc
+  | Digest_files _
+  | Promote _ -> acc
 
 include Make_mapper(Ast)(Ast)
 
@@ -688,6 +734,36 @@ let rec exec t ~ectx ~dir ~env_extra ~stdout_to ~stderr_to =
         (Marshal.to_string data [])
     in
     exec_echo stdout_to s
+  | Promote { mode; files } ->
+    let promote_mode = !Clflags.promote_mode in
+    if promote_mode = Ignore then
+      return ()
+    else begin
+      let files =
+        match mode with
+        | Always -> files
+        | If_corrected_file_exists ->
+          List.filter files ~f:(fun file -> Path.exists file.Promote.src)
+      in
+      let not_ok =
+        List.filter files ~f:(fun { Promote. src; dst } ->
+          let src_contents = Io.read_file (Path.to_string src) in
+          let dst_contents = Io.read_file (Path.to_string dst) in
+          src_contents <> dst_contents)
+      in
+      match not_ok with
+      | [] -> return ()
+      | _ ->
+        if promote_mode = Copy then
+          Future.Scheduler.at_exit_after_waiting_for_commands (fun () ->
+            List.iter not_ok ~f:(fun { Promote. src; dst } ->
+              Format.eprintf "Promoting %s to %s.@."
+                (Path.to_string_maybe_quoted src)
+                (Path.to_string_maybe_quoted dst);
+              Io.copy_file ~src:(Path.to_string src) ~dst:(Path.to_string dst)));
+        Future.all_unit (List.map not_ok ~f:(fun { Promote. src; dst } ->
+          Diff.print dst src))
+    end
 
 and redirect outputs fn t ~ectx ~dir ~env_extra ~stdout_to ~stderr_to =
   let fn = Path.to_string fn in
@@ -752,6 +828,13 @@ module Infer = struct
   end
   open Outcome
 
+  let infer_promote mode files ~init ~f =
+    if mode = Promote_mode.If_corrected_file_exists ||
+       !Clflags.promote_mode = Ignore then
+      init
+    else
+      List.fold_left files ~init ~f
+
   let ( +@ ) acc fn = { acc with targets = S.add fn acc.targets }
   let ( +< ) acc fn = { acc with deps    = S.add fn acc.deps    }
 
@@ -771,6 +854,8 @@ module Infer = struct
     | Ignore (_, t) -> infer acc t
     | Progn l -> List.fold_left l ~init:acc ~f:infer
     | Digest_files l -> List.fold_left l ~init:acc ~f:(+<)
+    | Promote { mode; files } ->
+      infer_promote mode files ~init:acc ~f:(fun acc file -> acc +< file.Promote.src)
     | Echo _
     | System _
     | Bash _
@@ -812,6 +897,9 @@ module Infer = struct
     | Ignore (_, t) -> partial acc t
     | Progn l -> List.fold_left l ~init:acc ~f:partial
     | Digest_files l -> List.fold_left l ~init:acc ~f:(+<?)
+    | Promote { mode; files } ->
+      infer_promote mode files ~init:acc ~f:(fun acc file ->
+        acc +<? file.Unexpanded.Partial.Promote.src)
     | Echo _
     | System _
     | Bash _
@@ -839,6 +927,9 @@ module Infer = struct
     | Ignore (_, t) -> partial_with_all_targets acc t
     | Progn l -> List.fold_left l ~init:acc ~f:partial_with_all_targets
     | Digest_files l -> List.fold_left l ~init:acc ~f:(+<?)
+    | Promote { mode; files } ->
+      infer_promote mode files ~init:acc ~f:(fun acc file ->
+        acc +<? file.Unexpanded.Partial.Promote.src)
     | Echo _
     | System _
     | Bash _

--- a/src/action.mli
+++ b/src/action.mli
@@ -14,6 +14,8 @@ end
 
 module Outputs : module type of struct include Action_intf.Outputs end
 
+module Promote_mode = Action_intf.Promote_mode
+
 (** result of the lookup of a program, the path to it or information about the
     failure and possibly a hint how to fix it *)
 module Prog : sig

--- a/src/action_intf.ml
+++ b/src/action_intf.ml
@@ -5,10 +5,25 @@ module Outputs = struct
     | Outputs (** Both Stdout and Stderr *)
 end
 
+module Promote_mode = struct
+  type t =
+    | If_corrected_file_exists
+    | Always
+end
+
 module type Ast = sig
   type program
   type path
   type string
+
+  module Promote : sig
+    type file = { src : path; dst : path }
+
+    type t =
+      { mode  : Promote_mode.t
+      ; files : file list
+      }
+  end
 
   type t =
     | Run            of program * string list
@@ -29,6 +44,7 @@ module type Ast = sig
     | Remove_tree    of path
     | Mkdir          of path
     | Digest_files   of path list
+    | Promote        of Promote.t
 end
 
 module type Helpers = sig

--- a/src/clflags.ml
+++ b/src/clflags.ml
@@ -11,8 +11,21 @@ let external_lib_deps_hint = ref []
 let capture_outputs = ref true
 let debug_backtraces = ref false
 let diff_command = ref None
-type promote_mode =
-  | Ignore
-  | Check
-  | Copy
-let promote_mode = ref Check
+module Promote_mode = struct
+  type t =
+    | Ignore
+    | Check
+    | Copy
+
+  let to_string = function
+    | Ignore -> "ignore"
+    | Check -> "check"
+    | Copy -> "copy"
+
+  let of_string = function
+    | "ignore" -> Some Ignore
+    | "check" -> Some Check
+    | "copy" -> Some Copy
+    | _ -> None
+end
+let promote_mode = ref Promote_mode.Check

--- a/src/clflags.ml
+++ b/src/clflags.ml
@@ -10,3 +10,9 @@ let workspace_root = ref "."
 let external_lib_deps_hint = ref []
 let capture_outputs = ref true
 let debug_backtraces = ref false
+let diff_command = ref None
+type promote_mode =
+  | Ignore
+  | Check
+  | Copy
+let promote_mode = ref Check

--- a/src/clflags.mli
+++ b/src/clflags.mli
@@ -39,9 +39,15 @@ val debug_backtraces : bool ref
 (** Command to use to diff things *)
 val diff_command : string option ref
 
-type promote_mode =
-  | Ignore (** We ignore 'promote' stanzas and actions *)
-  | Check  (** Just check for equality *)
-  | Copy   (** If the correction is different, copy the file to the source tree *)
+module Promote_mode : sig
+  type t =
+    | Ignore (** We ignore 'promote' stanzas and actions *)
+    | Check  (** Just check for equality *)
+    | Copy   (** If the correction is different,
+                 copy the file to the source tree *)
 
-val promote_mode : promote_mode ref
+  val to_string : t -> string
+  val of_string : string -> t option
+end
+
+val promote_mode : Promote_mode.t ref

--- a/src/clflags.mli
+++ b/src/clflags.mli
@@ -35,3 +35,13 @@ val capture_outputs : bool ref
 
 (** Always print backtraces, to help debugging jbuilder itself *)
 val debug_backtraces : bool ref
+
+(** Command to use to diff things *)
+val diff_command : string option ref
+
+type promote_mode =
+  | Ignore (** We ignore 'promote' stanzas and actions *)
+  | Check  (** Just check for equality *)
+  | Copy   (** If the correction is different, copy the file to the source tree *)
+
+val promote_mode : promote_mode ref

--- a/src/diff.ml
+++ b/src/diff.ml
@@ -1,0 +1,43 @@
+open Import
+
+let ( >>= ) = Future.( >>= )
+
+let print file1 file2 =
+  let loc = Loc.in_file (Path.to_string file1) in
+  let fallback () =
+    die "%aFiles \"%s\" and \"%s\" differ." Loc.print loc
+      (Path.to_string file1) (Path.to_string file2)
+  in
+  let normal_diff () =
+    match Bin.which "diff" with
+    | None -> fallback ()
+    | Some prog ->
+      Format.eprintf "%a@?" Loc.print loc;
+      Future.run Strict (Path.to_string prog)
+        ["-u"; Path.to_string file1; Path.to_string file2]
+      >>= fun () ->
+      die "diff reported no differences on \"%s\" and \"%s\""
+        (Path.to_string file1) (Path.to_string file2)
+  in
+  match !Clflags.diff_command with
+  | Some cmd ->
+    let sh, arg = Utils.system_shell_exn ~needed_to:"print diffs" in
+    let q fn = Filename.quote (Path.to_string fn) in
+    let cmd = sprintf "%s %s %s" cmd (q file1) (q file2) in
+    Future.run Strict (Path.to_string sh) [arg; cmd]
+    >>= fun () ->
+    die "command reported no differences: %s" cmd
+  | None ->
+    match Bin.which "patdiff" with
+    | None -> normal_diff ()
+    | Some prog ->
+      Future.run Strict (Path.to_string prog)
+        [ "-keep-whitespace"
+        ; "-location-style"; "omake"
+        ; "-unrefined"
+        ; Path.to_string file1
+        ; Path.to_string file2
+        ]
+      >>= fun () ->
+      (* Use "diff" if "patdiff" reported no differences *)
+      normal_diff ()

--- a/src/diff.mli
+++ b/src/diff.mli
@@ -1,0 +1,2 @@
+(** Diff two files that are expected not to match. *)
+val print : Path.t -> Path.t -> _ Future.t

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -260,6 +260,12 @@ end
 module Stanzas : sig
   type t = Stanza.t list
 
-  val parse : Scope.t -> Sexp.Ast.t list -> t
+  type syntax = OCaml | Plain
+
+  val parse
+    :  ?default_version:Jbuild_version.t
+    -> Scope.t
+    -> Sexp.Ast.t list
+    -> t
   val lib_names : (_ * _ * t) list -> String_set.t
 end

--- a/test/blackbox-tests/jbuild
+++ b/test/blackbox-tests/jbuild
@@ -169,3 +169,10 @@
   (action
    (chdir test-cases/cross-compilation
     (setenv JBUILDER ${bin:jbuilder} (run ${exe:cram.exe} run.t))))))
+
+(alias
+ ((name runtest)
+  (deps ((files_recursively_in test-cases/promote)))
+  (action
+   (chdir test-cases/promote
+    (setenv JBUILDER ${bin:jbuilder} (run ${exe:cram.exe} run.t))))))

--- a/test/blackbox-tests/test-cases/promote/jbuild
+++ b/test/blackbox-tests/test-cases/promote/jbuild
@@ -1,0 +1,7 @@
+(jbuild_version 1)
+
+(rule (with-stdout-to x.gen (echo "toto")))
+
+(alias
+ ((name blah)
+  (action (promote (x.gen as x)))))

--- a/test/blackbox-tests/test-cases/promote/run.t
+++ b/test/blackbox-tests/test-cases/promote/run.t
@@ -1,0 +1,21 @@
+  $ echo titi > x
+
+  $ $JBUILDER build --root . -j1 --diff-command false @blah
+            sh (internal) (exit 1)
+  /usr/bin/sh -c 'false '\''x'\'' '\''_build/default/x.gen'\'''
+  [1]
+  $ cat x
+  titi
+
+  $ $JBUILDER build --root . -j1 --diff-command false @blah --promote ignore
+  $ cat x
+  titi
+
+  $ $JBUILDER build --root . -j1 --diff-command false @blah --promote copy
+            sh (internal) (exit 1)
+  /usr/bin/sh -c 'false '\''x'\'' '\''_build/default/x.gen'\'''
+  Promoting _build/default/x.gen to x.
+  [1]
+  $ cat x
+  toto
+  $ $JBUILDER build --root . -j1 --diff-command false @blah --promote copy


### PR DESCRIPTION
This PR implements something similar to what was discussed in #371 except for toplevel `(promote ...)` stanza which will be part of another PR.

## Motivations

This PR makes it easier to have generated files that are committed in the source code repository. This method has a few use cases:
- to handle bootstrapping issues
- for single use code generators, when it's easier to review the generated code than the code generator itself

In particular, it provides a nice way to have a jbuild files that are generated and committed in the source tree. This is used in jbuilder itself, in `doc/jbuild`.

Additionally, this PR provide the necessary support for tools that generate *corrected* files, such as expectation tests, some ppx rewriters, etc...

## Details

This PR adds two new forms in actions:
- `(promote (<a> as <b>) (<c> as <d>) ...)`
- `(promote-if (<a> as <b>) (<c> as <d>) ...)`

Both these forms takes as argument a list of S-expression of the form `(<file1> as <file2>)`. Every form `(<file1> as <file2>)` means that `<file1>` is a generated file and we want to copy it as `<file2>` directly in the source tree. The only difference between the two forms is that `promote-if` will ignore entries where the generated file doesn't exist. This is for a special case detailed below.

In any case, when the generated files are promoted, all the entries in the list are processed at once as this sometimes matters for consistency. For instance, if we were using this in the OCaml compiler itself, we would write this in `boot/jbuild`:

```scheme
(alias
 ((name bootstrap)
  (action (promote (../ocamlc as ocamlc) (../ocamldep as ocamldep) ...))))
```

Jbuilder currently doesn't support dynamic generation of jbuild files, however, using this feature, one can have a generated jbuild file that is committed in the source tree and kept up-to-date. Since in such cases we often want both static stanzas and generated ones, this PR also add an `(include <file>)` stanza, used to include the contents of another source file in the current jbuild file. By combining include and promotion, one can do the following:

```scheme
(include jbuild.inc)

(rule (with-stdout-to jbuild.inc.gen (run ./gen-jbuild)))

(alias
 ((name update-jbuild)
  (action (promote (jbuild.inc.gen as jbuild.inc)))))
```

### `--promote` command line argument

The interpretation of promote actions is controlled via the command line option `--promote <mode>` which supports the 3 following mode:

- `ignore`: completely ignore promote actions
- `check`: check that the two files are equal and print a diff if not
- `copy`: same as check, but additionally copy over the generated file to the source tree.  This is the default

The actual copy is always done after the build has completed, to avoid race conditions.

The `-p/--for-release-of-packages` command line option implies `--promote ignore`. This option is meant for release builds and ignoring promotion will often cut down the number of dependencies and speed up the build.

## Usage for `.corrected` files

Several systems such as expectation tests, `[@@deriving_inline ...]` attribute, cinaps, etc... work by checking that the source file is a quine. I.e. the interpretation of some specific elements in the source files will produce some output that will immediately these elements in the source tree. For instance with expectation tests:

```ocaml
print_string "hello";
[%expect "hello"]
```

Such systems work by interpreting such elements, replacing the expectation by the actual output and checking the resulting file is the same as the source file. When there are not, a diff must be displayed to the user and optionally the corrected file must be copied over to the source tree.

`promote-if` is intended to handle such cases, and in particular unify the management of such corrected files. For instance, when running expectation tests, the test runtime might generate some `file.ml.corrected` files. What we can do is add `(promote-if (file.ml.corrected file.ml) ...)` after the execution of the test to let jbuilder handle the diffing and promotion.

Currently, these systems all handle the diffing and sometimes promotion themselves. However the promotion part, when done is not compatible with jbuilder as it performs the build in a separate directory. They will need to be slightly modified in order to work with this mechanism.

